### PR TITLE
By default, throw errors from `MethodError`

### DIFF
--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -283,8 +283,10 @@ function GenericOperatorEnum(;
         Base.print(io::IO, tree::Node) = print(io, string_tree(tree, $operators))
         Base.show(io::IO, tree::Node) = print(io, string_tree(tree, $operators))
 
-        function (tree::Node)(X)
-            out, did_finish = eval_tree_array(tree, X, $operators)
+        function (tree::Node)(X; throw_errors::Bool=true)
+            out, did_finish = eval_tree_array(
+                tree, X, $operators; throw_errors=throw_errors
+            )
             if !did_finish
                 return nothing
             end

--- a/test/test_error_handling.jl
+++ b/test/test_error_handling.jl
@@ -1,0 +1,35 @@
+using DynamicExpressions
+using Test
+
+# Test that we generate errors:
+scalar_add(x::T, y::T) where {T<:Real} = x + y
+operators = GenericOperatorEnum(; binary_operators=[scalar_add], extend_user_operators=true)
+tree = scalar_add(x1, x2)
+
+# With error handling:
+try
+    eval_tree_array(tree, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], operators; catch_errors=true)
+    @test false
+catch e
+    @test isa(e, ErrorException)
+    expected_error_msg = "Failed to evaluate tree"
+    @test occursin(expected_error_msg, e.msg)
+end
+
+# Without error handling:
+output, flag = eval_tree_array(
+    tree, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], operators; catch_errors=false
+)
+@test output === nothing
+@test !flag
+
+# Default is to catch errors:
+try
+    tree([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    @test false
+catch e
+    @test isa(e, ErrorException)
+end
+
+# But can be overrided:
+output = tree([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]; catch_errors=false)

--- a/test/test_error_handling.jl
+++ b/test/test_error_handling.jl
@@ -2,13 +2,20 @@ using DynamicExpressions
 using Test
 
 # Test that we generate errors:
+baseT = Float64
+T = Union{baseT,Vector{baseT},Matrix{baseT}}
+
 scalar_add(x::T, y::T) where {T<:Real} = x + y
+
 operators = GenericOperatorEnum(; binary_operators=[scalar_add], extend_user_operators=true)
-tree = scalar_add(x1, x2)
+
+x1, x2, x3 = [Node(T; feature=i) for i in 1:3]
+
+tree = Node(1, x1, x2)
 
 # With error handling:
 try
-    eval_tree_array(tree, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], operators; catch_errors=true)
+    eval_tree_array(tree, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], operators; throw_errors=true)
     @test false
 catch e
     @test isa(e, ErrorException)
@@ -18,7 +25,7 @@ end
 
 # Without error handling:
 output, flag = eval_tree_array(
-    tree, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], operators; catch_errors=false
+    tree, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], operators; throw_errors=false
 )
 @test output === nothing
 @test !flag
@@ -32,4 +39,4 @@ catch e
 end
 
 # But can be overrided:
-output = tree([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]; catch_errors=false)
+output = tree([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]; throw_errors=false)

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -51,3 +51,7 @@ end
 @safetestset "Test tensor operators" begin
     include("test_tensor_operators.jl")
 end
+
+@safetestset "Test error handling" begin
+    include("test_error_handling.jl")
+end


### PR DESCRIPTION
Right now, in `eval_tree_array(::Node, ::AbstractArray, ::GenericOperatorEnum)`, `MethodError`s are caught before they occur, and nothing is returned. This is faster, but may not be what a user expects. 

This introduces a new keyword argument `throw_error` to `eval_tree_array` (only the generic version) which can be turned on (default) to throw `MethodError`s, or off, to cleanly catch them and return nothing. In practice, it can be faster to simply return early, rather than to throw and catch an error.