### PR TITLE
Safer way of extending user-defined operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicExpressions"
 uuid = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -159,19 +159,28 @@ x1 = Node(String; feature=1)
 This node, will be used to index input data (whatever it may be) with either `data[feature]` (1D abstract arrays) or `selectdim(data, 1, feature)` (ND abstract arrays). Let's now define some operators to use:
 
 ```julia
-my_string_func(x::String) = "Hello $x"
+my_string_func(x::String) = "ello $x"
 
 operators = GenericOperatorEnum(;
     binary_operators=[*],
-    unary_operators=[my_string_func],
-    extend_user_operators=true)
+    unary_operators=[my_string_func]
+)
+```
+
+Now, let's extend our operators to work with the
+expression types used by `DynamicExpressions.jl`:
+
+```julia
+@extend_operators operators
 ```
 
 Now, let's create an expression:
 
 ```julia
-tree = x1 * " World!"
-tree(["Hello", "Me?"])
+tree = "H" * my_string_func(x1)
+# ^ `(H * my_string_func(x1))`
+
+tree(["World!", "Me?"])
 # Hello World!
 ```
 
@@ -202,7 +211,8 @@ vec_add(x, y) = x .+ y
 vec_square(x) = x .* x
 
 # Set up an operator enum:
-operators = GenericOperatorEnum(;binary_operators=[vec_add], unary_operators=[vec_square], extend_user_operators=true)
+operators = GenericOperatorEnum(;binary_operators=[vec_add], unary_operators=[vec_square])
+@extend_operators operators
 
 # Construct the expression:
 tree = vec_add(vec_add(vec_square(x1), c2), c1)

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -13,15 +13,34 @@ OperatorEnum
 Construct this operator specification as follows:
 
 ```@docs
-OperatorEnum(; binary_operators, unary_operators, enable_autodiff)
+OperatorEnum(; binary_operators=[], unary_operators=[], enable_autodiff::Bool=false, define_helper_functions::Bool=true)
 ```
 
 This is just for scalar real operators. However, you can use
 the following for more general operators:
 
 ```@docs
-GenericOperatorEnum(; binary_operators=[], unary_operators=[], extend_user_operators::Bool=false)
+GenericOperatorEnum(; binary_operators=[], unary_operators=[], define_helper_functions::Bool=true)
 ```
+
+By default, these operators will define helper functions for constructing trees,
+so that you can write `Node(;feature=1) + Node(;feature=2)` instead of
+`Node(1, Node(;feature=1), Node(;feature=2))` (assuming `+` is the first operator).
+You can turn this off with `define_helper_functions=false`.
+
+For other operators *not* found in `Base`, including user-defined functions, you may
+use the `@extend_operators` macro:
+
+```@docs
+@extend_operators operators
+```
+
+This will extend the operators you have passed to work with `Node` types, so that
+it is easier to construct expression trees.
+
+Note that you are free to use the `Node` constructors directly.
+This is a more robust approach, and should be used when creating libraries
+which use `DynamicExpressions.jl`.
 
 ## Equations
 

--- a/src/DynamicExpressions.jl
+++ b/src/DynamicExpressions.jl
@@ -24,7 +24,8 @@ using Reexport
     get_constants,
     set_constants
 @reexport import .OperatorEnumModule: AbstractOperatorEnum
-@reexport import .OperatorEnumConstructionModule: OperatorEnum, GenericOperatorEnum
+@reexport import .OperatorEnumConstructionModule:
+    OperatorEnum, GenericOperatorEnum, @extend_operators
 @reexport import .EvaluateEquationModule: eval_tree_array, differentiable_eval_tree_array
 @reexport import .EvaluateEquationDerivativeModule:
     eval_diff_tree_array, eval_grad_tree_array

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -198,7 +198,7 @@ macro extend_operators_base(operators)
 end
 
 """
-    OperatorEnum(; binary_operators=[], unary_operators=[], enable_autodiff::Bool=false, extend_user_operators::Bool=false)
+    OperatorEnum(; binary_operators=[], unary_operators=[], enable_autodiff::Bool=false, define_helper_functions::Bool=true)
 
 Construct an `OperatorEnum` object, defining the possible expressions. This will also
 redefine operators for `Node` types, as well as `show`, `print`, and `(::Node)(X)`.
@@ -210,8 +210,6 @@ It will automatically compute derivatives with `Zygote.jl`.
 - `unary_operators::Vector{Function}`: A vector of functions, each of which is a unary
   operator.
 - `enable_autodiff::Bool=false`: Whether to enable automatic differentiation.
-- `extend_user_operators::Bool=false`: Whether to extend the user's operators to
-  `Node` types. All operators defined in `Base` will already be extended automatically.
 - `define_helper_functions::Bool=true`: Whether to define helper functions for creating
    and evaluating node types. Turn this off when doing precompilation. Note that these
    are *not* needed for the package to work; they are purely for convenience.
@@ -220,7 +218,6 @@ function OperatorEnum(;
     binary_operators=[],
     unary_operators=[],
     enable_autodiff::Bool=false,
-    extend_user_operators::Bool=false,
     define_helper_functions::Bool=true,
 )
     @assert length(binary_operators) > 0 || length(unary_operators) > 0
@@ -281,7 +278,7 @@ function OperatorEnum(;
     )
 
     if define_helper_functions
-        create_construction_helpers!(operators; extend_user_operators=extend_user_operators)
+        @extend_operators_base operators
         create_evaluation_helpers!(operators)
     end
 
@@ -289,7 +286,7 @@ function OperatorEnum(;
 end
 
 """
-    GenericOperatorEnum(; binary_operators=[], unary_operators=[], extend_user_operators::Bool=false)
+    GenericOperatorEnum(; binary_operators=[], unary_operators=[], define_helper_functions::Bool=true)
 
 Construct a `GenericOperatorEnum` object, defining possible expressions.
 Unlike `OperatorEnum`, this enum one will work arbitrary operators and data types.
@@ -301,17 +298,12 @@ and `(::Node)(X)`.
   operator on real scalars.
 - `unary_operators::Vector{Function}`: A vector of functions, each of which is a unary
   operator on real scalars.
-- `extend_user_operators::Bool=false`: Whether to extend the user's operators to
-  `Node` types. All operators defined in `Base` will already be extended automatically.
 - `define_helper_functions::Bool=true`: Whether to define helper functions for creating
    and evaluating node types. Turn this off when doing precompilation. Note that these
    are *not* needed for the package to work; they are purely for convenience.
 """
 function GenericOperatorEnum(;
-    binary_operators=[],
-    unary_operators=[],
-    extend_user_operators::Bool=false,
-    define_helper_functions::Bool=true,
+    binary_operators=[], unary_operators=[], define_helper_functions::Bool=true
 )
     binary_operators = Tuple(binary_operators)
     unary_operators = Tuple(unary_operators)
@@ -322,7 +314,7 @@ function GenericOperatorEnum(;
     operators = GenericOperatorEnum(binary_operators, unary_operators)
 
     if define_helper_functions
-        create_construction_helpers!(operators; extend_user_operators=extend_user_operators)
+        @extend_operators_base operators
         create_evaluation_helpers!(operators)
     end
 

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -166,7 +166,7 @@ function _extend_operators(operators, skip_user_operators, __module__::Module)
 end
 
 """
-    @extend_operators(operators)
+    @extend_operators operators
 
 Extends all operators defined in this operator enum to work on the
 `Node` type. While by default this is already done for operators defined
@@ -187,7 +187,7 @@ macro extend_operators(operators)
 end
 
 """
-    @extend_operators_base(operators)
+    @extend_operators_base operators
 
 Similar to `@extend_operators`, but only extends operators already
 defined in `Base`.

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -11,22 +11,12 @@ function create_evaluation_helpers!(operators::OperatorEnum)
     @eval begin
         Base.print(io::IO, tree::Node) = print(io, string_tree(tree, $operators))
         Base.show(io::IO, tree::Node) = print(io, string_tree(tree, $operators))
-        function (tree::Node{T})(
-            X::AbstractArray{T,2}; kws...
-        )::AbstractArray{T,1} where {T<:Real}
+        function (tree::Node)(X; kws...)
             out, did_finish = eval_tree_array(tree, X, $operators; kws...)
             if !did_finish
                 out .= convert(eltype(out), NaN)
             end
             return out
-        end
-        function (tree::Node{T1})(X::AbstractArray{T2,2}; kws...) where {T1<:Real,T2<:Real}
-            if T1 != T2
-                T = promote_type(T1, T2)
-                tree = convert(Node{T}, tree)
-                X = T.(X)
-            end
-            return tree(X; kws...)
         end
         # Gradients:
         function Base.adjoint(tree::Node{T}) where {T}

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -15,7 +15,7 @@ function create_evaluation_helpers!(operators::OperatorEnum)
             length(keys(kws)) > 1 && error("Unknown keyword argument: $(key)")
             out, did_finish = eval_tree_array(tree, X, $operators)
             if !did_finish
-                out .= T(NaN)
+                out .= convert(eltype(out), NaN)
             end
             return out
         end

--- a/test/test_custom_operators.jl
+++ b/test/test_custom_operators.jl
@@ -1,0 +1,58 @@
+using DynamicExpressions
+using Test
+using Random
+
+# Test that we can work with custom operators:
+function op1(x::T, y::T)::T where {T<:Real}
+    return x + y
+end
+function op2(x::T, y::T)::T where {T<:Real}
+    return x^2 + 1 / ((y)^2 + 0.1)
+end
+function op3(x::T)::T where {T<:Real}
+    return sin(x) + cos(x)
+end
+local operators, tree
+operators = OperatorEnum(; binary_operators=(op1, op2), unary_operators=(op3,))
+@extend_operators operators
+x1 = Node(; feature=1)
+x2 = Node(; feature=2)
+tree = op1(op2(x1, x2), op3(x1))
+@test repr(tree) == "op1(op2(x1, x2), op3(x1))"
+# Test evaluation:
+X = randn(MersenneTwister(0), Float32, 2, 10);
+@test tree(X) ≈ ((x1, x2) -> op1(op2(x1, x2), op3(x1))).(X[1, :], X[2, :])
+
+# Now, test that we can work with operators defined in modules
+module A
+
+using DynamicExpressions
+using Random
+
+function my_func_a(x::T, y::T) where {T<:Real}
+    return x^2 * y
+end
+
+function my_func_b(x::T) where {T<:Real}
+    return x^3
+end
+
+operators = OperatorEnum(; binary_operators=[my_func_a], unary_operators=[my_func_b])
+@extend_operators operators
+
+function create_and_eval_tree()
+    x1 = Node(Float64; feature=1)
+    x2 = Node(Float64; feature=2)
+    c1 = Node(Float64; val=0.2)
+    tree = my_func_a(my_func_a(x2, 0.2), my_func_b(x1))
+    func = (x1, x2) -> my_func_a(my_func_a(x2, 0.2), my_func_b(x1))
+    X = randn(MersenneTwister(0), 2, 20)
+    return tree(X), func.(X[1, :], X[2, :])
+end
+
+end
+
+# Now, test that we can work with operators defined in other modules
+import .A: create_and_eval_tree
+prediction, truth = create_and_eval_tree()
+@test prediction ≈ truth

--- a/test/test_error_handling.jl
+++ b/test/test_error_handling.jl
@@ -7,11 +7,12 @@ T = Union{baseT,Vector{baseT},Matrix{baseT}}
 
 scalar_add(x::T, y::T) where {T<:Real} = x + y
 
-operators = GenericOperatorEnum(; binary_operators=[scalar_add], extend_user_operators=true)
+operators = GenericOperatorEnum(; binary_operators=[scalar_add])
 
 x1, x2, x3 = [Node(T; feature=i) for i in 1:3]
 
-tree = Node(1, x1, x2)
+@extend_operators operators
+tree = scalar_add(x1, x2)
 
 # With error handling:
 try

--- a/test/test_evaluation.jl
+++ b/test/test_evaluation.jl
@@ -66,15 +66,7 @@ for turbo in [false, true],
     true_y = realfnc.(X[1, :], X[2, :], X[3, :])
 
     zero_tolerance = (T == Float16 ? 1e-4 : 1e-6)
-    try
-        @test all(abs.(test_y .- true_y) / N .< zero_tolerance)
-    catch
-        println("Test for type $T and turbo=$turbo and function $i_func $tree failed.")
-        mse = sum((x,) -> x^2, test_y .- true_y) / N
-        mean = sum(test_y) / N
-        stdev = sqrt(sum((x,) -> x^2, true_y .- mean) / N)
-        println("Relative error: $(mse / stdev)")
-    end
+    @test all(abs.(test_y .- true_y) / N .< zero_tolerance)
 end
 
 for turbo in [false, true], T in [Float16, Float32, Float64]
@@ -116,7 +108,7 @@ for turbo in [false, true], T in [Float16, Float32, Float64]
     x1 = Node(T; feature=1)
     tree = sin(x1 / 0.0)
     X = randn(Float32, 3, 10)
-    @test isnan(tree(X)[1])
+    @test isnan(tree(X; turbo=turbo)[1])
 end
 
 # And, with generic operator enum, this should be an actual error:

--- a/test/test_evaluation.jl
+++ b/test/test_evaluation.jl
@@ -68,7 +68,6 @@ for turbo in [false, true], T in [Float16, Float32, Float64], fnc in functions
     @test all(abs.(test_y .- true_y) / N .< zero_tolerance)
 end
 
-
 for turbo in [false, true], T in [Float16, Float32, Float64]
     turbo && T == Float16 && continue
     # Test specific branches of evaluation code:
@@ -99,15 +98,14 @@ for turbo in [false, true], T in [Float16, Float32, Float64]
     @test DynamicExpressions.EvaluateEquationModule.deg1_l2_ll0_lr0_eval(
         tree, [zero(T)]', Val(1), Val(1), operators, Val(turbo)
     )[1][1] ≈ truth
-    
+
     # Test for presence of NaNs:
     operators = OperatorEnum(; binary_operators=[+, -, *, /], unary_operators=[cos, sin])
     x1 = Node(T; feature=1)
     tree = sin(x1 / 0.0)
-    X = randn(Float32, 3, 10);
+    X = randn(Float32, 3, 10)
     @test isnan(tree(X)[1])
 end
-
 
 # And, with generic operator enum, this should be an actual error:
 operators = GenericOperatorEnum(; binary_operators=[+, -, *, /], unary_operators=[cos, sin])

--- a/test/test_tensor_operators.jl
+++ b/test/test_tensor_operators.jl
@@ -8,7 +8,7 @@ function vec_add(x, y)
     return x .+ y
 end
 
-operators = GenericOperatorEnum(; binary_operators=[vec_add], extend_user_operators=true)
+operators = GenericOperatorEnum(; binary_operators=[vec_add])
 
 x1, x2, x3 = [Node(T; feature=i) for i in 1:3]
 c1 = Node(T; val=[1.0, 2.0, 3.0])
@@ -22,20 +22,30 @@ tree = Node(1, x1, c1)
 @test repr(tree) == "vec_add(x1, [1.0, 2.0, 3.0])"
 @test tree(X) == [3.0, 4.0, 5.0]
 
+# Try same things, but with constructors:
+@extend_operators operators
+tree = vec_add(c1, x2)
+@test repr(tree) == "vec_add([1.0, 2.0, 3.0], x2)"
+@test tree(X) == [4.0, 5.0, 6.0]
+tree = vec_add(x1, c1)
+@test repr(tree) == "vec_add(x1, [1.0, 2.0, 3.0])"
+@test tree(X) == [3.0, 4.0, 5.0]
+
 # Also test unary operators:
 function vec_square(x)
     return x .* x
 end
 
-operators = GenericOperatorEnum(;
-    binary_operators=[vec_add], unary_operators=[vec_square], extend_user_operators=true
-)
+operators = GenericOperatorEnum(; binary_operators=[vec_add], unary_operators=[vec_square])
+@extend_operators operators
 tree = Node(1, c1)
 @test repr(tree) == "vec_square([1.0, 2.0, 3.0])"
 @test tree(X) == [1.0, 4.0, 9.0]
+@test vec_square(c1).val == [1.0, 4.0, 9.0]
 tree = Node(1, Node(1, c1), x1)
 @test repr(tree) == "vec_add(vec_square([1.0, 2.0, 3.0]), x1)"
 @test tree(X) == [3.0, 6.0, 11.0]
+@test (vec_add(vec_square(c1), x1))(X) == [3.0, 6.0, 11.0]
 
 # Also test mixed scalar and floats:
 c2 = Node(T; val=2.0)

--- a/test/test_tree_construction.jl
+++ b/test/test_tree_construction.jl
@@ -112,12 +112,14 @@ function op1(x, y)
     return x + y
 end
 function op2(x, y)
-    return x ^ 2 + 1/((y)^2 + 0.1)
+    return x^2 + 1 / ((y)^2 + 0.1)
 end
 function op3(x)
     return sin(x) + cos(x)
 end
-operators = OperatorEnum(; default_params..., binary_operators=(op1, op2), unary_operators=(op3,))
+operators = OperatorEnum(;
+    default_params..., binary_operators=(op1, op2), unary_operators=(op3,)
+)
 @extend_operators operators
 x1 = Node(; feature=1)
 x2 = Node(; feature=2)

--- a/test/test_tree_construction.jl
+++ b/test/test_tree_construction.jl
@@ -117,6 +117,7 @@ end
 function op3(x)
     return sin(x) + cos(x)
 end
+local operators, tree
 operators = OperatorEnum(;
     default_params..., binary_operators=(op1, op2), unary_operators=(op3,)
 )
@@ -125,3 +126,6 @@ x1 = Node(; feature=1)
 x2 = Node(; feature=2)
 tree = op1(op2(x1, x2), op3(x1))
 @test repr(tree) == "op1(op2(x1, x2), op3(x1))"
+# Test evaluation:
+X = randn(MersenneTwister(0), 2, 10);
+@test tree(X) ≈ ((x1, x2) -> op1(op2(x1, x2), op3(x1))).(X[1, :], X[2, :])

--- a/test/test_tree_construction.jl
+++ b/test/test_tree_construction.jl
@@ -106,3 +106,20 @@ s = String(take!(io))
 set_node!(tree, tree2)
 @test tree !== tree2
 @test repr(tree) == repr(tree2)
+
+# Test that we can work with custom operators:
+function op1(x, y)
+    return x + y
+end
+function op2(x, y)
+    return x ^ 2 + 1/((y)^2 + 0.1)
+end
+function op3(x)
+    return sin(x) + cos(x)
+end
+operators = OperatorEnum(; default_params..., binary_operators=(op1, op2), unary_operators=(op3,))
+@extend_operators operators
+x1 = Node(; feature=1)
+x2 = Node(; feature=2)
+tree = op1(op2(x1, x2), op3(x1))
+@test repr(tree) == "op1(op2(x1, x2), op3(x1))"

--- a/test/test_tree_construction.jl
+++ b/test/test_tree_construction.jl
@@ -106,26 +106,3 @@ s = String(take!(io))
 set_node!(tree, tree2)
 @test tree !== tree2
 @test repr(tree) == repr(tree2)
-
-# Test that we can work with custom operators:
-function op1(x, y)
-    return x + y
-end
-function op2(x, y)
-    return x^2 + 1 / ((y)^2 + 0.1)
-end
-function op3(x)
-    return sin(x) + cos(x)
-end
-local operators, tree
-operators = OperatorEnum(;
-    default_params..., binary_operators=(op1, op2), unary_operators=(op3,)
-)
-@extend_operators operators
-x1 = Node(; feature=1)
-x2 = Node(; feature=2)
-tree = op1(op2(x1, x2), op3(x1))
-@test repr(tree) == "op1(op2(x1, x2), op3(x1))"
-# Test evaluation:
-X = randn(MersenneTwister(0), 2, 10);
-@test tree(X) ≈ ((x1, x2) -> op1(op2(x1, x2), op3(x1))).(X[1, :], X[2, :])

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -59,3 +59,7 @@ end
 @safetestset "Test equality operator" begin
     include("test_equality.jl")
 end
+
+@safetestset "Test operators within module" begin
+    include("test_custom_operators.jl")
+end


### PR DESCRIPTION
This PR makes it safer to extend user-defined operators. Now, you can extend operators like so:

```julia
using DynamicExpressions

my_op(x::String, y::String) = x * y

operators = GenericOperatorEnum(; binary_operators=[my_op])

@extend_operators operators

x1 = Node(String; feature=1)
tree = my_op(x1, " World!")

tree(["Hello"])
# Hello World!
```

This macro will take into account what module called the macro, and define it in the same scope. Thus, it will be much safer than the current method which is a bit of a hack. This new approach is a single macro which spits out a bunch of functions like so:
```julia
function Base.:(+)(l::Node{T}, r::Node{T}) where {T}
    return Node(1, l, r)
end
```
(assuming that `+` is the first operator).

The downside is that the macro is very complex.

---

It works for functions defined in modules too:
```julia
module A
using DynamicExpressions
function f(x, y)
   x + y ^ 2
end
const operators = OperatorEnum(;binary_operators=[+, f])
@extend_operators operators
end
```
Then, we can use functions as follows:
```julia
julia> Main.A.f
f (generic function with 7 methods)
```

---

@odow if you have time, I would be eager to hear your thoughts on this!