### PR TITLE
Use `LoopVectorization.@turbo` in dynamic expression evaluation scheme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/src/EvaluateEquation.jl
+++ b/src/EvaluateEquation.jl
@@ -1,5 +1,6 @@
 module EvaluateEquationModule
 
+import LoopVectorization: @turbo, indices
 import ..EquationModule: Node, string_tree
 import ..OperatorEnumModule: OperatorEnum, GenericOperatorEnum
 import ..UtilsModule: @return_on_false, is_bad_array, vals
@@ -132,8 +133,8 @@ function deg2_eval(
     op = operators.binops[op_idx]
 
     # We check inputs (and intermediates), not outputs.
-    @inbounds @simd for j in 1:n
-        x = op(cumulator[j], array2[j])::T
+    @turbo for j in indices(cumulator)
+        x = op(cumulator[j], array2[j])
         cumulator[j] = x
     end
     # return (cumulator, finished_loop) #
@@ -148,8 +149,8 @@ function deg1_eval(
     @return_on_false complete cumulator
     @return_on_nonfinite_array cumulator T n
     op = operators.unaops[op_idx]
-    @inbounds @simd for j in 1:n
-        x = op(cumulator[j])::T
+    @turbo for j in indices(cumulator)
+        x = op(cumulator[j])
         cumulator[j] = x
     end
     return (cumulator, true) #
@@ -191,9 +192,9 @@ function deg1_l2_ll0_lr0_eval(
         @return_on_check val_ll T n
         feature_lr = tree.l.r.feature
         cumulator = Array{T,1}(undef, n)
-        @inbounds @simd for j in 1:n
-            x_l = op_l(val_ll, cX[feature_lr, j])::T
-            x = isfinite(x_l) ? op(x_l)::T : T(Inf) # These will get discovered by _eval_tree_array at end.
+        @turbo for j in indices((cX, cumulator), (2, 1))
+            x_l = op_l(val_ll, cX[feature_lr, j])
+            x = isfinite(x_l) ? op(x_l) : T(Inf) # These will get discovered by _eval_tree_array at end.
             cumulator[j] = x
         end
         return (cumulator, true)
@@ -202,9 +203,9 @@ function deg1_l2_ll0_lr0_eval(
         val_lr = tree.l.r.val::T
         @return_on_check val_lr T n
         cumulator = Array{T,1}(undef, n)
-        @inbounds @simd for j in 1:n
-            x_l = op_l(cX[feature_ll, j], val_lr)::T
-            x = isfinite(x_l) ? op(x_l)::T : T(Inf)
+        @turbo for j in indices((cX, cumulator), (2, 1))
+            x_l = op_l(cX[feature_ll, j], val_lr)
+            x = isfinite(x_l) ? op(x_l) : T(Inf)
             cumulator[j] = x
         end
         return (cumulator, true)
@@ -212,9 +213,9 @@ function deg1_l2_ll0_lr0_eval(
         feature_ll = tree.l.l.feature
         feature_lr = tree.l.r.feature
         cumulator = Array{T,1}(undef, n)
-        @inbounds @simd for j in 1:n
-            x_l = op_l(cX[feature_ll, j], cX[feature_lr, j])::T
-            x = isfinite(x_l) ? op(x_l)::T : T(Inf)
+        @turbo for j in indices((cX, cumulator), (2, 1))
+            x_l = op_l(cX[feature_ll, j], cX[feature_lr, j])
+            x = isfinite(x_l) ? op(x_l) : T(Inf)
             cumulator[j] = x
         end
         return (cumulator, true)
@@ -243,9 +244,9 @@ function deg1_l1_ll0_eval(
     else
         feature_ll = tree.l.l.feature
         cumulator = Array{T,1}(undef, n)
-        @inbounds @simd for j in 1:n
-            x_l = op_l(cX[feature_ll, j])::T
-            x = isfinite(x_l) ? op(x_l)::T : T(Inf)
+        @turbo for j in indices((cX, cumulator), (2, 1))
+            x_l = op_l(cX[feature_ll, j])
+            x = isfinite(x_l) ? op(x_l) : T(Inf)
             cumulator[j] = x
         end
         return (cumulator, true)
@@ -270,8 +271,8 @@ function deg2_l0_r0_eval(
         val_l = tree.l.val::T
         @return_on_check val_l T n
         feature_r = tree.r.feature
-        @inbounds @simd for j in 1:n
-            x = op(val_l, cX[feature_r, j])::T
+        @turbo for j in indices((cX, cumulator), (2, 1))
+            x = op(val_l, cX[feature_r, j])
             cumulator[j] = x
         end
     elseif tree.r.constant
@@ -279,16 +280,16 @@ function deg2_l0_r0_eval(
         feature_l = tree.l.feature
         val_r = tree.r.val::T
         @return_on_check val_r T n
-        @inbounds @simd for j in 1:n
-            x = op(cX[feature_l, j], val_r)::T
+        @turbo for j in indices((cX, cumulator), (2, 1))
+            x = op(cX[feature_l, j], val_r)
             cumulator[j] = x
         end
     else
         cumulator = Array{T,1}(undef, n)
         feature_l = tree.l.feature
         feature_r = tree.r.feature
-        @inbounds @simd for j in 1:n
-            x = op(cX[feature_l, j], cX[feature_r, j])::T
+        @turbo for j in indices((cX, cumulator), (2, 1))
+            x = op(cX[feature_l, j], cX[feature_r, j])
             cumulator[j] = x
         end
     end
@@ -306,14 +307,14 @@ function deg2_l0_eval(
     if tree.l.constant
         val = tree.l.val::T
         @return_on_check val T n
-        @inbounds @simd for j in 1:n
-            x = op(val, cumulator[j])::T
+        @turbo for j in indices(cumulator)
+            x = op(val, cumulator[j])
             cumulator[j] = x
         end
     else
         feature = tree.l.feature
-        @inbounds @simd for j in 1:n
-            x = op(cX[feature, j], cumulator[j])::T
+        @turbo for j in indices((cX, cumulator), (2, 1))
+            x = op(cX[feature, j], cumulator[j])
             cumulator[j] = x
         end
     end
@@ -331,14 +332,14 @@ function deg2_r0_eval(
     if tree.r.constant
         val = tree.r.val::T
         @return_on_check val T n
-        @inbounds @simd for j in 1:n
-            x = op(cumulator[j], val)::T
+        @turbo for j in indices(cumulator)
+            x = op(cumulator[j], val)
             cumulator[j] = x
         end
     else
         feature = tree.r.feature
-        @inbounds @simd for j in 1:n
-            x = op(cumulator[j], cX[feature, j])::T
+        @turbo for j in indices((cX, cumulator), (2, 1))
+            x = op(cumulator[j], cX[feature, j])
             cumulator[j] = x
         end
     end

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -11,25 +11,29 @@ function create_evaluation_helpers!(operators::OperatorEnum)
     @eval begin
         Base.print(io::IO, tree::Node) = print(io, string_tree(tree, $operators))
         Base.show(io::IO, tree::Node) = print(io, string_tree(tree, $operators))
-        function (tree::Node{T})(X::AbstractArray{T,2})::AbstractArray{T,1} where {T<:Real}
-            out, did_finish = eval_tree_array(tree, X, $operators)
+        function (tree::Node{T})(
+            X::AbstractArray{T,2}; kws...
+        )::AbstractArray{T,1} where {T<:Real}
+            out, did_finish = eval_tree_array(tree, X, $operators; kws...)
             if !did_finish
                 out .= T(NaN)
             end
             return out
         end
-        function (tree::Node{T1})(X::AbstractArray{T2,2}) where {T1<:Real,T2<:Real}
+        function (tree::Node{T1})(X::AbstractArray{T2,2}; kws...) where {T1<:Real,T2<:Real}
             if T1 != T2
                 T = promote_type(T1, T2)
                 tree = convert(Node{T}, tree)
                 X = T.(X)
             end
-            return tree(X)
+            return tree(X; kws...)
         end
         # Gradients:
         function Base.adjoint(tree::Node{T}) where {T}
-            return X -> begin
-                _, grad, did_complete = eval_grad_tree_array(tree, X, $operators; variable=true)
+            return (X; kws...) -> begin
+                _, grad, did_complete = eval_grad_tree_array(
+                    tree, X, $operators; variable=true, kws...
+                )
                 !did_complete && (grad .= T(NaN))
                 grad
             end
@@ -42,10 +46,8 @@ function create_evaluation_helpers!(operators::GenericOperatorEnum)
         Base.print(io::IO, tree::Node) = print(io, string_tree(tree, $operators))
         Base.show(io::IO, tree::Node) = print(io, string_tree(tree, $operators))
 
-        function (tree::Node)(X; throw_errors::Bool=true)
-            out, did_finish = eval_tree_array(
-                tree, X, $operators; throw_errors=throw_errors
-            )
+        function (tree::Node)(X; kws...)
+            out, did_finish = eval_tree_array(tree, X, $operators; kws...)
             if !did_finish
                 return nothing
             end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -7,7 +7,7 @@ using LoopVectorization: @turbo
 function _remove_type_assertions(ex::Expr)
     if ex.head == :(::)
         @assert length(ex.args) == 2
-        return ex.args[1]
+        return _remove_type_assertions(ex.args[1])
     else
         return Expr(ex.head, map(_remove_type_assertions, ex.args)...)
     end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,6 +1,47 @@
 """Useful functions to be used throughout the library."""
 module UtilsModule
 
+using LoopVectorization: @turbo
+
+"""Remove all type assertions in an expression."""
+function _remove_type_assertions(ex::Expr)
+    if ex.head == :(::)
+        @assert length(ex.args) == 2
+        return ex.args[1]
+    else
+        return Expr(ex.head, map(_remove_type_assertions, ex.args)...)
+    end
+end
+
+function _remove_type_assertions(ex)
+    return ex
+end
+
+"""
+    @maybe_turbo use_turbo expression
+
+Use @turbo if flag is true; otherwise @inbounds @simd.
+This will also remove all type assertions from the expression.
+"""
+macro maybe_turbo(turboflag, ex)
+    # Thanks @jlapeyre https://discourse.julialang.org/t/optional-macro-invocation/18588
+    clean_ex = _remove_type_assertions(ex)
+    turbo_ex = Expr(:macrocall, Symbol("@turbo"), LineNumberNode(@__LINE__), clean_ex)
+    simple_ex = Expr(
+        :macrocall,
+        Symbol("@inbounds"),
+        LineNumberNode(@__LINE__),
+        Expr(:macrocall, Symbol("@simd"), LineNumberNode(@__LINE__), ex),
+    )
+    quote
+        if $(esc(turboflag))
+            $(esc(turbo_ex))
+        else
+            $(esc(simple_ex))
+        end
+    end
+end
+
 macro return_on_false(flag, retval)
     :(
         if !$(esc(flag))

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -48,6 +48,7 @@ for type in [Float16, Float32, Float64]
     nfeatures = 3
     N = 100
 
+    local X, operators
     X = rand(rng, type, nfeatures, N) * 5
 
     operators = OperatorEnum(;
@@ -63,6 +64,7 @@ for type in [Float16, Float32, Float64]
             continue
         end
 
+        local tree
         tree = convert(Node{type}, equation(nx1, nx2, nx3))
         predicted_output = eval_tree_array(tree, X, operators)[1]
         true_output = equation.([X[i, :] for i in 1:nfeatures]...)
@@ -96,6 +98,7 @@ for type in [Float16, Float32, Float64]
     # Test gradient with respect to constants:
     equation4(x1, x2, x3) = 3.2f0 * x1
     # The gradient should be: (C * x1) => x1 is gradient with respect to C.
+    local tree
     tree = equation4(nx1, nx2, nx3)
     tree = convert(Node{type}, tree)
     predicted_grad = eval_grad_tree_array(tree, X, operators; variable=false)[2]

--- a/test/test_evaluation.jl
+++ b/test/test_evaluation.jl
@@ -8,49 +8,41 @@ operators = OperatorEnum(;
     default_params..., binary_operators=(+, *, /, -), unary_operators=(cos, sin)
 )
 
-# Here, we unittest the fast function evaluation scheme
-# We need to trigger all possible fused functions, with all their logic.
-# These are as follows:
-
-## We fuse (and compile) the following:
-##  - op(op2(x, y)), where x, y, z are constants or variables.
-##  - op(op2(x)), where x is a constant or variable.
-##  - op(x), for any x.
-## We fuse (and compile) the following:
-##  - op(x, y), where x, y are constants or variables.
-##  - op(x, y), where x is a constant or variable but y is not.
-##  - op(x, y), where y is a constant or variable but x is not.
-##  - op(x, y), for any x or y
-for fnc in [
+functions = [
     # deg2_l0_r0_eval
     (x1, x2, x3) -> x1 * x2,
-    (x1, x2, x3) -> x1 * 3.0f0,
-    (x1, x2, x3) -> 3.0f0 * x2,
-    (((x1, x2, x3) -> 3.0f0 * 6.0f0), ((x1, x2, x3) -> Node(; val=3.0f0) * 6.0f0)),
+    (x1, x2, x3) -> x1 * 3.0,
+    (x1, x2, x3) -> 3.0 * x2,
+    (((x1, x2, x3) -> 3.0 * 6.0), ((x1, x2, x3) -> Node(; val=3.0) * 6.0)),
     # deg2_l0_eval
     (x1, x2, x3) -> x1 * sin(x2),
-    (x1, x2, x3) -> 3.0f0 * sin(x2),
+    (x1, x2, x3) -> 3.0 * sin(x2),
 
     # deg2_r0_eval
     (x1, x2, x3) -> sin(x1) * x2,
-    (x1, x2, x3) -> sin(x1) * 3.0f0,
+    (x1, x2, x3) -> sin(x1) * 3.0,
 
     # deg1_l2_ll0_lr0_eval
     (x1, x2, x3) -> cos(x1 * x2),
-    (x1, x2, x3) -> cos(x1 * 3.0f0),
-    (x1, x2, x3) -> cos(3.0f0 * x2),
+    (x1, x2, x3) -> cos(x1 * 3.0),
+    (x1, x2, x3) -> cos(3.0 * x2),
     (
-        ((x1, x2, x3) -> cos(3.0f0 * -0.5f0)),
-        ((x1, x2, x3) -> cos(Node(2, Node(; val=3.0f0), Node(; val=-0.5f0)))),
+        ((x1, x2, x3) -> cos(3.0 * -0.5)),
+        ((x1, x2, x3) -> cos(Node(2, Node(; val=3.0), Node(; val=-0.5)))),
     ),
 
     # deg1_l1_ll0_eval
     (x1, x2, x3) -> cos(sin(x1)),
-    (((x1, x2, x3) -> cos(sin(3.0f0))), ((x1, x2, x3) -> cos(sin(Node(; val=3.0f0))))),
+    (((x1, x2, x3) -> cos(sin(3.0))), ((x1, x2, x3) -> cos(sin(Node(; val=3.0))))),
 
     # everything else:
-    (x1, x2, x3) -> (sin(cos(sin(cos(x1) * x3) * 3.0f0) * -0.5f0) + 2.0f0) * 5.0f0,
+    (x1, x2, x3) -> (sin(cos(sin(cos(x1) * x3) * 3.0) * -0.5) + 2.0) * 5.0,
 ]
+
+for turbo in [false, true], T in [Float16, Float32, Float64], fnc in functions
+
+    # Float16 not implemented:
+    turbo && T == Float16 && continue
 
     # check if fnc is tuple
     if typeof(fnc) <: Tuple
@@ -61,40 +53,49 @@ for fnc in [
         nodefnc = fnc
     end
 
-    global tree = nodefnc(Node("x1"), Node("x2"), Node("x3"))
+    local tree, X
+    tree = nodefnc(Node("x1"), Node("x2"), Node("x3"))
+    tree = convert(Node{T}, tree)
 
     N = 100
     nfeatures = 3
-    X = randn(MersenneTwister(0), Float32, nfeatures, N)
+    X = randn(MersenneTwister(0), T, nfeatures, N)
 
-    test_y = eval_tree_array(tree, X, operators)[1]
+    test_y = eval_tree_array(tree, X, operators; turbo=turbo)[1]
     true_y = realfnc.(X[1, :], X[2, :], X[3, :])
 
-    zero_tolerance = 1e-6
+    zero_tolerance = (T == Float16 ? 1e-4 : 1e-6)
     @test all(abs.(test_y .- true_y) / N .< zero_tolerance)
 end
 
-# Test specific branches of evaluation code:
-# op(op(<constant>))
-tree = Node(1, Node(1, Node(; val=3.0f0)))
-@test repr(tree) == "cos(cos(3.0))"
-truth = cos(cos(3.0f0))
-@test DynamicExpressions.EvaluateEquationModule.deg1_l1_ll0_eval(
-    tree, [0.0f0]', Val(1), Val(1), operators
-)[1][1] ≈ truth
+for turbo in [false, true], T in [Float16, Float32, Float64]
+    turbo && T == Float16 && continue
+    # Test specific branches of evaluation code:
+    # op(op(<constant>))
+    local tree
+    tree = Node(1, Node(1, Node(; val=3.0f0)))
+    @test repr(tree) == "cos(cos(3.0))"
+    tree = convert(Node{T}, tree)
+    truth = cos(cos(T(3.0f0)))
+    @test DynamicExpressions.EvaluateEquationModule.deg1_l1_ll0_eval(
+        tree, [zero(T)]', Val(1), Val(1), operators, Val(turbo)
+    )[1][1] ≈ truth
 
-# op(<constant>, <constant>)
-tree = Node(1, Node(; val=3.0f0), Node(; val=4.0f0))
-@test repr(tree) == "(3.0 + 4.0)"
-truth = 3.0f0 + 4.0f0
-@test DynamicExpressions.EvaluateEquationModule.deg2_l0_r0_eval(
-    tree, [0.0f0]', Val(1), operators
-)[1][1] ≈ truth
+    # op(<constant>, <constant>)
+    tree = Node(1, Node(; val=3.0f0), Node(; val=4.0f0))
+    @test repr(tree) == "(3.0 + 4.0)"
+    tree = convert(Node{T}, tree)
+    truth = T(3.0f0) + T(4.0f0)
+    @test DynamicExpressions.EvaluateEquationModule.deg2_l0_r0_eval(
+        tree, [zero(T)]', Val(1), operators, Val(turbo)
+    )[1][1] ≈ truth
 
-# op(op(<constant>, <constant>))
-tree = Node(1, Node(1, Node(; val=3.0f0), Node(; val=4.0f0)))
-@test repr(tree) == "cos(3.0 + 4.0)"
-truth = cos(3.0f0 + 4.0f0)
-@test DynamicExpressions.EvaluateEquationModule.deg1_l2_ll0_lr0_eval(
-    tree, [0.0f0]', Val(1), Val(1), operators
-)[1][1] ≈ truth
+    # op(op(<constant>, <constant>))
+    tree = Node(1, Node(1, Node(; val=3.0f0), Node(; val=4.0f0)))
+    @test repr(tree) == "cos(3.0 + 4.0)"
+    tree = convert(Node{T}, tree)
+    truth = cos(T(3.0f0) + T(4.0f0))
+    @test DynamicExpressions.EvaluateEquationModule.deg1_l2_ll0_lr0_eval(
+        tree, [zero(T)]', Val(1), Val(1), operators, Val(turbo)
+    )[1][1] ≈ truth
+end


### PR DESCRIPTION
With https://github.com/JuliaSIMD/LoopVectorization.jl/pull/431, this should potentially work for arbitrary user-defined operators, since it will fall back to `@inbounds @simd` when an operator cannot be SIMD-ified. It gets the evaluation even faster for me - now evaluation about 30% faster than a simple handwritten function, and even a little bit faster than a manually-written SIMD loop (which does not use `@turbo`)

Let's see if this works.

cc @chriselrod