### PR TITLE
Reduce specialization in evaluation methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicExpressions"
 uuid = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/DynamicExpressions.jl
+++ b/src/DynamicExpressions.jl
@@ -39,4 +39,8 @@ const PACKAGE_VERSION = let
     VersionNumber(project["version"])
 end
 
+macro ignore(args...) end
+# To get LanguageServer to register library within tests
+@ignore include("../test/runtests.jl")
+
 end

--- a/src/EvaluateEquation.jl
+++ b/src/EvaluateEquation.jl
@@ -28,7 +28,7 @@ macro return_on_nonfinite_array(array, T, n)
 end
 
 """
-    eval_tree_array(tree::Node, cX::AbstractMatrix{T}, operators::OperatorEnum; turbo::Bool)
+    eval_tree_array(tree::Node, cX::AbstractMatrix{T}, operators::OperatorEnum; turbo::Bool=false)
 
 Evaluate a binary tree (equation) over a given input data matrix. The
 operators contain all of the operators used. This function fuses doublets

--- a/src/EvaluateEquation.jl
+++ b/src/EvaluateEquation.jl
@@ -149,12 +149,10 @@ end
 function deg2_eval(
     cumulator_l::AbstractVector{T}, cumulator_r::AbstractVector{T}, op::F, ::Val{turbo}
 )::Tuple{AbstractVector{T},Bool} where {T<:Real,F,turbo}
-    # We check inputs (and intermediates), not outputs.
     @maybe_turbo turbo for j in indices(cumulator_l)
         x = op(cumulator_l[j], cumulator_r[j])::T
         cumulator_l[j] = x
     end
-    # return (cumulator, finished_loop) #
     return (cumulator_l, true)
 end
 
@@ -171,8 +169,8 @@ end
 function deg0_eval(
     tree::Node{T}, cX::AbstractMatrix{T}
 )::Tuple{AbstractVector{T},Bool} where {T<:Real}
-    n = size(cX, 2)
     if tree.constant
+        n = size(cX, 2)
         return (fill(tree.val::T, n), true)
     else
         return (cX[tree.feature, :], true)

--- a/src/EvaluateEquation.jl
+++ b/src/EvaluateEquation.jl
@@ -3,7 +3,7 @@ module EvaluateEquationModule
 import LoopVectorization: @turbo, indices
 import ..EquationModule: Node, string_tree
 import ..OperatorEnumModule: OperatorEnum, GenericOperatorEnum
-import ..UtilsModule: @return_on_false, @maybe_turbo, is_bad_array, vals
+import ..UtilsModule: @return_on_false, @maybe_turbo, is_bad_array
 import ..EquationUtilsModule: is_constant
 
 macro return_on_check(val, T, n)
@@ -98,45 +98,41 @@ function _eval_tree_array(
         !flag && return Array{T,1}(undef, size(cX, 2)), false
         return fill(result, size(cX, 2)), true
     elseif tree.degree == 1
+        op = operators.unaops[tree.op]
         if tree.l.degree == 2 && tree.l.l.degree == 0 && tree.l.r.degree == 0
             # op(op2(x, y)), where x, y, z are constants or variables.
-            return deg1_l2_ll0_lr0_eval(
-                tree, cX, vals[tree.op], vals[tree.l.op], operators, Val(turbo)
-            )
+            op_l = operators.binops[tree.l.op]
+            return deg1_l2_ll0_lr0_eval(tree, cX, op, op_l, Val(turbo))
         elseif tree.l.degree == 1 && tree.l.l.degree == 0
             # op(op2(x)), where x is a constant or variable.
-            return deg1_l1_ll0_eval(
-                tree, cX, vals[tree.op], vals[tree.l.op], operators, Val(turbo)
-            )
+            op_l = operators.unaops[tree.l.op]
+            return deg1_l1_ll0_eval(tree, cX, op, op_l, Val(turbo))
         else
             # op(x), for any x.
-            return deg1_eval(tree, cX, vals[tree.op], operators, Val(turbo))
+            return deg1_eval(tree, cX, op, operators, Val(turbo))
         end
     elseif tree.degree == 2
         # TODO - add op(op2(x, y), z) and op(x, op2(y, z))
+        op = operators.binops[tree.op]
         if tree.l.degree == 0 && tree.r.degree == 0
             # op(x, y), where x, y are constants or variables.
-            return deg2_l0_r0_eval(tree, cX, vals[tree.op], operators, Val(turbo))
+            return deg2_l0_r0_eval(tree, cX, op, Val(turbo))
         elseif tree.l.degree == 0
             # op(x, y), where x is a constant or variable but y is not.
-            return deg2_l0_eval(tree, cX, vals[tree.op], operators, Val(turbo))
+            return deg2_l0_eval(tree, cX, op, operators, Val(turbo))
         elseif tree.r.degree == 0
             # op(x, y), where y is a constant or variable but x is not.
-            return deg2_r0_eval(tree, cX, vals[tree.op], operators, Val(turbo))
+            return deg2_r0_eval(tree, cX, op, operators, Val(turbo))
         else
             # op(x, y), for any x or y
-            return deg2_eval(tree, cX, vals[tree.op], operators, Val(turbo))
+            return deg2_eval(tree, cX, op, operators, Val(turbo))
         end
     end
 end
 
 function deg2_eval(
-    tree::Node{T},
-    cX::AbstractMatrix{T},
-    ::Val{op_idx},
-    operators::OperatorEnum,
-    ::Val{turbo},
-)::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx,turbo}
+    tree::Node{T}, cX::AbstractMatrix{T}, op::F, operators::OperatorEnum, ::Val{turbo}
+)::Tuple{AbstractVector{T},Bool} where {T<:Real,F,turbo}
     n = size(cX, 2)
     (cumulator, complete) = _eval_tree_array(tree.l, cX, operators, Val(turbo))
     @return_on_false complete cumulator
@@ -144,7 +140,6 @@ function deg2_eval(
     (array2, complete2) = _eval_tree_array(tree.r, cX, operators, Val(turbo))
     @return_on_false complete2 cumulator
     @return_on_nonfinite_array array2 T n
-    op = operators.binops[op_idx]
 
     # We check inputs (and intermediates), not outputs.
     @maybe_turbo turbo for j in indices(cumulator)
@@ -156,22 +151,17 @@ function deg2_eval(
 end
 
 function deg1_eval(
-    tree::Node{T},
-    cX::AbstractMatrix{T},
-    ::Val{op_idx},
-    operators::OperatorEnum,
-    ::Val{turbo},
-)::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx,turbo}
+    tree::Node{T}, cX::AbstractMatrix{T}, op::F, operators::OperatorEnum, ::Val{turbo}
+)::Tuple{AbstractVector{T},Bool} where {T<:Real,F,turbo}
     n = size(cX, 2)
     (cumulator, complete) = _eval_tree_array(tree.l, cX, operators, Val(turbo))
     @return_on_false complete cumulator
     @return_on_nonfinite_array cumulator T n
-    op = operators.unaops[op_idx]
     @maybe_turbo turbo for j in indices(cumulator)
         x = op(cumulator[j])::T
         cumulator[j] = x
     end
-    return (cumulator, true) #
+    return (cumulator, true)
 end
 
 function deg0_eval(
@@ -188,14 +178,11 @@ end
 function deg1_l2_ll0_lr0_eval(
     tree::Node{T},
     cX::AbstractMatrix{T},
-    ::Val{op_idx},
-    ::Val{op_l_idx},
-    operators::OperatorEnum,
+    op::F,
+    op_l::F2,
     ::Val{turbo},
-)::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx,op_l_idx,turbo}
+)::Tuple{AbstractVector{T},Bool} where {T<:Real,F,F2,turbo}
     n = size(cX, 2)
-    op = operators.unaops[op_idx]
-    op_l = operators.binops[op_l_idx]
     if tree.l.l.constant && tree.l.r.constant
         val_ll = tree.l.l.val::T
         val_lr = tree.l.r.val::T
@@ -245,14 +232,11 @@ end
 function deg1_l1_ll0_eval(
     tree::Node{T},
     cX::AbstractMatrix{T},
-    ::Val{op_idx},
-    ::Val{op_l_idx},
-    operators::OperatorEnum,
+    op::F,
+    op_l::F2,
     ::Val{turbo},
-)::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx,op_l_idx,turbo}
+)::Tuple{AbstractVector{T},Bool} where {T<:Real,F,F2,turbo}
     n = size(cX, 2)
-    op = operators.unaops[op_idx]
-    op_l = operators.unaops[op_l_idx]
     if tree.l.l.constant
         val_ll = tree.l.l.val::T
         @return_on_check val_ll T n
@@ -275,14 +259,9 @@ end
 
 # op(x, y) for x and y variable/constant
 function deg2_l0_r0_eval(
-    tree::Node{T},
-    cX::AbstractMatrix{T},
-    ::Val{op_idx},
-    operators::OperatorEnum,
-    ::Val{turbo},
-)::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx,turbo}
+    tree::Node{T}, cX::AbstractMatrix{T}, op::F, ::Val{turbo}
+)::Tuple{AbstractVector{T},Bool} where {T<:Real,F,turbo}
     n = size(cX, 2)
-    op = operators.binops[op_idx]
     if tree.l.constant && tree.r.constant
         val_l = tree.l.val::T
         @return_on_check val_l T n
@@ -323,17 +302,12 @@ end
 
 # op(x, y) for x variable/constant, y arbitrary
 function deg2_l0_eval(
-    tree::Node{T},
-    cX::AbstractMatrix{T},
-    ::Val{op_idx},
-    operators::OperatorEnum,
-    ::Val{turbo},
-)::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx,turbo}
+    tree::Node{T}, cX::AbstractMatrix{T}, op::F, operators::OperatorEnum, ::Val{turbo}
+)::Tuple{AbstractVector{T},Bool} where {T<:Real,F,turbo}
     n = size(cX, 2)
     (cumulator, complete) = _eval_tree_array(tree.r, cX, operators, Val(turbo))
     @return_on_false complete cumulator
     @return_on_nonfinite_array cumulator T n
-    op = operators.binops[op_idx]
     if tree.l.constant
         val = tree.l.val::T
         @return_on_check val T n
@@ -353,17 +327,12 @@ end
 
 # op(x, y) for x arbitrary, y variable/constant
 function deg2_r0_eval(
-    tree::Node{T},
-    cX::AbstractMatrix{T},
-    ::Val{op_idx},
-    operators::OperatorEnum,
-    ::Val{turbo},
-)::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx,turbo}
+    tree::Node{T}, cX::AbstractMatrix{T}, op::F, operators::OperatorEnum, ::Val{turbo}
+)::Tuple{AbstractVector{T},Bool} where {T<:Real,F,turbo}
     n = size(cX, 2)
     (cumulator, complete) = _eval_tree_array(tree.l, cX, operators, Val(turbo))
     @return_on_false complete cumulator
     @return_on_nonfinite_array cumulator T n
-    op = operators.binops[op_idx]
     if tree.r.constant
         val = tree.r.val::T
         @return_on_check val T n
@@ -394,9 +363,9 @@ function _eval_constant_tree(
     if tree.degree == 0
         return deg0_eval_constant(tree)
     elseif tree.degree == 1
-        return deg1_eval_constant(tree, vals[tree.op], operators)
+        return deg1_eval_constant(tree, operators.unaops[tree.op], operators)
     else
-        return deg2_eval_constant(tree, vals[tree.op], operators)
+        return deg2_eval_constant(tree, operators.binops[tree.op], operators)
     end
 end
 
@@ -405,9 +374,8 @@ end
 end
 
 function deg1_eval_constant(
-    tree::Node{T}, ::Val{op_idx}, operators::OperatorEnum
-)::Tuple{T,Bool} where {T<:Real,op_idx}
-    op = operators.unaops[op_idx]
+    tree::Node{T}, op::F, operators::OperatorEnum
+)::Tuple{T,Bool} where {T<:Real,F}
     (cumulator, complete) = _eval_constant_tree(tree.l, operators)
     !complete && return zero(T), false
     output = op(cumulator)::T
@@ -415,9 +383,8 @@ function deg1_eval_constant(
 end
 
 function deg2_eval_constant(
-    tree::Node{T}, ::Val{op_idx}, operators::OperatorEnum
-)::Tuple{T,Bool} where {T<:Real,op_idx}
-    op = operators.binops[op_idx]
+    tree::Node{T}, op::F, operators::OperatorEnum
+)::Tuple{T,Bool} where {T<:Real,F}
     (cumulator, complete) = _eval_constant_tree(tree.l, operators)
     !complete && return zero(T), false
     (cumulator2, complete2) = _eval_constant_tree(tree.r, operators)
@@ -442,31 +409,29 @@ function differentiable_eval_tree_array(
             return (cX[tree.feature, :], true)
         end
     elseif tree.degree == 1
-        return deg1_diff_eval(tree, cX, vals[tree.op], operators)
+        return deg1_diff_eval(tree, cX, operators.unaops[tree.op], operators)
     else
-        return deg2_diff_eval(tree, cX, vals[tree.op], operators)
+        return deg2_diff_eval(tree, cX, operators.binops[tree.op], operators)
     end
 end
 
 function deg1_diff_eval(
-    tree::Node{T1}, cX::AbstractMatrix{T}, ::Val{op_idx}, operators::OperatorEnum
-)::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx,T1}
+    tree::Node{T1}, cX::AbstractMatrix{T}, op::F, operators::OperatorEnum
+)::Tuple{AbstractVector{T},Bool} where {T<:Real,F,T1}
     (left, complete) = differentiable_eval_tree_array(tree.l, cX, operators)
     @return_on_false complete left
-    op = operators.unaops[op_idx]
     out = op.(left)
     no_nans = !any(x -> (!isfinite(x)), out)
     return (out, no_nans)
 end
 
 function deg2_diff_eval(
-    tree::Node{T1}, cX::AbstractMatrix{T}, ::Val{op_idx}, operators::OperatorEnum
-)::Tuple{AbstractVector{T},Bool} where {T<:Real,op_idx,T1}
+    tree::Node{T1}, cX::AbstractMatrix{T}, op::F, operators::OperatorEnum
+)::Tuple{AbstractVector{T},Bool} where {T<:Real,F,T1}
     (left, complete) = differentiable_eval_tree_array(tree.l, cX, operators)
     @return_on_false complete left
     (right, complete2) = differentiable_eval_tree_array(tree.r, cX, operators)
     @return_on_false complete2 left
-    op = operators.binops[op_idx]
     out = op.(left, right)
     no_nans = !any(x -> (!isfinite(x)), out)
     return (out, no_nans)
@@ -557,30 +522,28 @@ function _eval_tree_array_generic(
             end
         end
     elseif tree.degree == 1
-        return deg1_eval_generic(tree, cX, vals[tree.op], operators, Val(throw_errors))
+        return deg1_eval_generic(tree, cX, operators.unaops[tree.op], operators, Val(throw_errors))
     else
-        return deg2_eval_generic(tree, cX, vals[tree.op], operators, Val(throw_errors))
+        return deg2_eval_generic(tree, cX, operators.binops[tree.op], operators, Val(throw_errors))
     end
 end
 
 function deg1_eval_generic(
-    tree, cX, ::Val{op_idx}, operators::GenericOperatorEnum, ::Val{throw_errors}
-) where {op_idx,throw_errors}
+    tree, cX, op::F, operators::GenericOperatorEnum, ::Val{throw_errors}
+) where {F,throw_errors}
     left, complete = eval_tree_array(tree.l, cX, operators)
     !throw_errors && !complete && return nothing, false
-    op = operators.unaops[op_idx]
     !throw_errors && !hasmethod(op, Tuple{typeof(left)}) && return nothing, false
     return op(left), true
 end
 
 function deg2_eval_generic(
-    tree, cX, ::Val{op_idx}, operators::GenericOperatorEnum, ::Val{throw_errors}
-) where {op_idx,throw_errors}
+    tree, cX, op::F, operators::GenericOperatorEnum, ::Val{throw_errors}
+) where {F,throw_errors}
     left, complete = eval_tree_array(tree.l, cX, operators)
     !throw_errors && !complete && return nothing, false
     right, complete = eval_tree_array(tree.r, cX, operators)
     !throw_errors && !complete && return nothing, false
-    op = operators.binops[op_idx]
     !throw_errors &&
         !hasmethod(op, Tuple{typeof(left),typeof(right)}) &&
         return nothing, false

--- a/src/EvaluateEquation.jl
+++ b/src/EvaluateEquation.jl
@@ -176,11 +176,7 @@ function deg0_eval(
 end
 
 function deg1_l2_ll0_lr0_eval(
-    tree::Node{T},
-    cX::AbstractMatrix{T},
-    op::F,
-    op_l::F2,
-    ::Val{turbo},
+    tree::Node{T}, cX::AbstractMatrix{T}, op::F, op_l::F2, ::Val{turbo}
 )::Tuple{AbstractVector{T},Bool} where {T<:Real,F,F2,turbo}
     n = size(cX, 2)
     if tree.l.l.constant && tree.l.r.constant
@@ -230,11 +226,7 @@ end
 
 # op(op2(x)) for x variable or constant
 function deg1_l1_ll0_eval(
-    tree::Node{T},
-    cX::AbstractMatrix{T},
-    op::F,
-    op_l::F2,
-    ::Val{turbo},
+    tree::Node{T}, cX::AbstractMatrix{T}, op::F, op_l::F2, ::Val{turbo}
 )::Tuple{AbstractVector{T},Bool} where {T<:Real,F,F2,turbo}
     n = size(cX, 2)
     if tree.l.l.constant
@@ -522,9 +514,13 @@ function _eval_tree_array_generic(
             end
         end
     elseif tree.degree == 1
-        return deg1_eval_generic(tree, cX, operators.unaops[tree.op], operators, Val(throw_errors))
+        return deg1_eval_generic(
+            tree, cX, operators.unaops[tree.op], operators, Val(throw_errors)
+        )
     else
-        return deg2_eval_generic(tree, cX, operators.binops[tree.op], operators, Val(throw_errors))
+        return deg2_eval_generic(
+            tree, cX, operators.binops[tree.op], operators, Val(throw_errors)
+        )
     end
 end
 

--- a/src/EvaluateEquationDerivative.jl
+++ b/src/EvaluateEquationDerivative.jl
@@ -8,7 +8,7 @@ import ..EquationUtilsModule: count_constants, index_constants, NodeIndex
 import ..EvaluateEquationModule: deg0_eval
 
 function assert_autodiff_enabled(operators::OperatorEnum)
-    if operators.diff_binops === nothing && operators.diff_unaops === nothing
+    if length(operators.diff_binops) == 0 && length(operators.diff_unaops) == 0
         error(
             "Found no differential operators. Did you forget to set `enable_autodiff=true` when creating the `OperatorEnum`?",
         )

--- a/src/EvaluateEquationDerivative.jl
+++ b/src/EvaluateEquationDerivative.jl
@@ -60,9 +60,23 @@ function _eval_diff_tree_array(
     evaluation, derivative, complete = if tree.degree == 0
         diff_deg0_eval(tree, cX, direction)
     elseif tree.degree == 1
-        diff_deg1_eval(tree, cX, operators.unaops[tree.op], operators.diff_unaops[tree.op], operators, direction)
+        diff_deg1_eval(
+            tree,
+            cX,
+            operators.unaops[tree.op],
+            operators.diff_unaops[tree.op],
+            operators,
+            direction,
+        )
     else
-        diff_deg2_eval(tree, cX, operators.binops[tree.op], operators.diff_binops[tree.op], operators, direction)
+        diff_deg2_eval(
+            tree,
+            cX,
+            operators.binops[tree.op],
+            operators.diff_binops[tree.op],
+            operators,
+            direction,
+        )
     end
     @return_on_false2 complete evaluation derivative
     return evaluation, derivative, !(is_bad_array(evaluation) || is_bad_array(derivative))

--- a/src/OperatorEnum.jl
+++ b/src/OperatorEnum.jl
@@ -12,12 +12,11 @@ Defines an enum over operators, along with their derivatives.
 - `diff_binops`: A tuple of Zygote-computed derivatives of the binary operators.
 - `diff_unaops`: A tuple of Zygote-computed derivatives of the unary operators.
 """
-struct OperatorEnum{A<:Tuple,B<:Tuple,dA<:Union{Tuple,Nothing},dB<:Union{Tuple,Nothing}} <:
-       AbstractOperatorEnum
-    binops::A
-    unaops::B
-    diff_binops::dA
-    diff_unaops::dB
+struct OperatorEnum <: AbstractOperatorEnum
+    binops::Vector{Function}
+    unaops::Vector{Function}
+    diff_binops::Vector{Function}
+    diff_unaops::Vector{Function}
 end
 
 """
@@ -30,9 +29,9 @@ Defines an enum over operators, along with their derivatives.
 - `diff_binops`: A tuple of Zygote-computed derivatives of the binary operators.
 - `diff_unaops`: A tuple of Zygote-computed derivatives of the unary operators.
 """
-struct GenericOperatorEnum{A<:Tuple,B<:Tuple} <: AbstractOperatorEnum
-    binops::A
-    unaops::B
+struct GenericOperatorEnum <: AbstractOperatorEnum
+    binops::Vector{Function}
+    unaops::Vector{Function}
 end
 
 end

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -227,9 +227,12 @@ function OperatorEnum(;
 
         test_inputs = Float32.(LinRange(-100, 100, 99))
         # Create grid over [-100, 100]^2:
-        test_inputs_xy = reduce(
-            hcat, reduce(hcat, ([[[x, y] for x in test_inputs] for y in test_inputs]))
-        )
+        test_inputs_xy = Array{Float32}(undef, 2, 99^2)
+        row = 1
+        for x in test_inputs, y in test_inputs
+            test_inputs_xy[:, row] .= [x, y]
+            row += 1
+        end
         for op in binary_operators
             diff_op(x, y) = gradient(op, x, y)
 

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -1,7 +1,6 @@
 module OperatorEnumConstructionModule
 
 import Zygote: gradient
-import ..UtilsModule: max_ops
 import ..OperatorEnumModule: AbstractOperatorEnum, OperatorEnum, GenericOperatorEnum
 import ..EquationModule: string_tree, Node
 import ..EvaluateEquationModule: eval_tree_array
@@ -218,7 +217,6 @@ function OperatorEnum(;
     define_helper_functions::Bool=true,
 )
     @assert length(binary_operators) > 0 || length(unary_operators) > 0
-    @assert length(binary_operators) <= max_ops && length(unary_operators) <= max_ops
     binary_operators = Tuple(binary_operators)
     unary_operators = Tuple(unary_operators)
 
@@ -306,7 +304,6 @@ function GenericOperatorEnum(;
     unary_operators = Tuple(unary_operators)
 
     @assert length(binary_operators) > 0 || length(unary_operators) > 0
-    @assert length(binary_operators) <= max_ops && length(unary_operators) <= max_ops
 
     operators = GenericOperatorEnum(binary_operators, unary_operators)
 

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -218,8 +218,8 @@ function OperatorEnum(;
 )
     @assert length(binary_operators) > 0 || length(unary_operators) > 0
 
-    binary_operators = convert(Vector{Function}, collect(binary_operators))
-    unary_operators = convert(Vector{Function}, collect(unary_operators))
+    binary_operators = Function[op for op in binary_operators]
+    unary_operators = Function[op for op in unary_operators]
 
     if enable_autodiff
         diff_binary_operators = Function[]

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -217,12 +217,13 @@ function OperatorEnum(;
     define_helper_functions::Bool=true,
 )
     @assert length(binary_operators) > 0 || length(unary_operators) > 0
-    binary_operators = Tuple(binary_operators)
-    unary_operators = Tuple(unary_operators)
+
+    binary_operators = convert(Vector{Function}, collect(binary_operators))
+    unary_operators = convert(Vector{Function}, collect(unary_operators))
 
     if enable_autodiff
-        diff_binary_operators = Any[]
-        diff_unary_operators = Any[]
+        diff_binary_operators = Function[]
+        diff_unary_operators = Function[]
 
         test_inputs = map(x -> convert(Float32, x), LinRange(-100, 100, 99))
         # Create grid over [-100, 100]^2:
@@ -259,13 +260,11 @@ function OperatorEnum(;
                 break
             end
         end
-        diff_binary_operators = Tuple(diff_binary_operators)
-        diff_unary_operators = Tuple(diff_unary_operators)
     end
 
     if !enable_autodiff
-        diff_binary_operators = nothing
-        diff_unary_operators = nothing
+        diff_binary_operators = Function[]
+        diff_unary_operators = Function[]
     end
 
     operators = OperatorEnum(
@@ -300,9 +299,6 @@ and `(::Node)(X)`.
 function GenericOperatorEnum(;
     binary_operators=[], unary_operators=[], define_helper_functions::Bool=true
 )
-    binary_operators = Tuple(binary_operators)
-    unary_operators = Tuple(unary_operators)
-
     @assert length(binary_operators) > 0 || length(unary_operators) > 0
 
     operators = GenericOperatorEnum(binary_operators, unary_operators)

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -225,7 +225,7 @@ function OperatorEnum(;
         diff_binary_operators = Function[]
         diff_unary_operators = Function[]
 
-        test_inputs = map(x -> convert(Float32, x), LinRange(-100, 100, 99))
+        test_inputs = Float32.(LinRange(-100, 100, 99))
         # Create grid over [-100, 100]^2:
         test_inputs_xy = reduce(
             hcat, reduce(hcat, ([[[x, y] for x in test_inputs] for y in test_inputs]))

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -304,6 +304,9 @@ function GenericOperatorEnum(;
 )
     @assert length(binary_operators) > 0 || length(unary_operators) > 0
 
+    binary_operators = Function[op for op in binary_operators]
+    unary_operators = Function[op for op in unary_operators]
+
     operators = GenericOperatorEnum(binary_operators, unary_operators)
 
     if define_helper_functions

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -79,7 +79,4 @@ isgood(x::T) where {T<:Number} = !(isnan(x) || !isfinite(x))
 isgood(x) = true
 isbad(x) = !isgood(x)
 
-const max_ops = 1024
-const vals = ntuple(i -> Val(i), max_ops)
-
 end

--- a/test/test_evaluation.jl
+++ b/test/test_evaluation.jl
@@ -82,7 +82,7 @@ for turbo in [false, true], T in [Float16, Float32, Float64]
     tree = convert(Node{T}, tree)
     truth = cos(cos(T(3.0f0)))
     @test DynamicExpressions.EvaluateEquationModule.deg1_l1_ll0_eval(
-        tree, [zero(T)]', cos, cos, operators, Val(turbo)
+        tree, [zero(T)]', cos, cos, Val(turbo)
     )[1][1] ≈ truth
 
     # op(<constant>, <constant>)
@@ -91,7 +91,7 @@ for turbo in [false, true], T in [Float16, Float32, Float64]
     tree = convert(Node{T}, tree)
     truth = T(3.0f0) + T(4.0f0)
     @test DynamicExpressions.EvaluateEquationModule.deg2_l0_r0_eval(
-        tree, [zero(T)]', (+), operators, Val(turbo)
+        tree, [zero(T)]', (+), Val(turbo)
     )[1][1] ≈ truth
 
     # op(op(<constant>, <constant>))
@@ -100,7 +100,7 @@ for turbo in [false, true], T in [Float16, Float32, Float64]
     tree = convert(Node{T}, tree)
     truth = cos(T(3.0f0) + T(4.0f0))
     @test DynamicExpressions.EvaluateEquationModule.deg1_l2_ll0_lr0_eval(
-        tree, [zero(T)]', cos, (+), operators, Val(turbo)
+        tree, [zero(T)]', cos, (+), Val(turbo)
     )[1][1] ≈ truth
 
     # Test for presence of NaNs:

--- a/test/test_evaluation.jl
+++ b/test/test_evaluation.jl
@@ -82,7 +82,7 @@ for turbo in [false, true], T in [Float16, Float32, Float64]
     tree = convert(Node{T}, tree)
     truth = cos(cos(T(3.0f0)))
     @test DynamicExpressions.EvaluateEquationModule.deg1_l1_ll0_eval(
-        tree, [zero(T)]', Val(1), Val(1), operators, Val(turbo)
+        tree, [zero(T)]', cos, cos, operators, Val(turbo)
     )[1][1] ≈ truth
 
     # op(<constant>, <constant>)
@@ -91,7 +91,7 @@ for turbo in [false, true], T in [Float16, Float32, Float64]
     tree = convert(Node{T}, tree)
     truth = T(3.0f0) + T(4.0f0)
     @test DynamicExpressions.EvaluateEquationModule.deg2_l0_r0_eval(
-        tree, [zero(T)]', Val(1), operators, Val(turbo)
+        tree, [zero(T)]', (+), operators, Val(turbo)
     )[1][1] ≈ truth
 
     # op(op(<constant>, <constant>))
@@ -100,7 +100,7 @@ for turbo in [false, true], T in [Float16, Float32, Float64]
     tree = convert(Node{T}, tree)
     truth = cos(T(3.0f0) + T(4.0f0))
     @test DynamicExpressions.EvaluateEquationModule.deg1_l2_ll0_lr0_eval(
-        tree, [zero(T)]', Val(1), Val(1), operators, Val(turbo)
+        tree, [zero(T)]', cos, (+), operators, Val(turbo)
     )[1][1] ≈ truth
 
     # Test for presence of NaNs:


### PR DESCRIPTION
This makes it so that the evaluation will only specialize to individual operators, rather than the entire set of operators. Thus, if you start with `OperatorEnum(; unary_operators=[sin, cos])`, and then run with `OperatorEnum(; unary_operators=[sin, cos, exp])`, it won't have to recompile the functions!

Surprisingly the evaluation is faster with the decreased specialization.... maybe because there's less function inference?