### PR TITLE
Deprecate implicit call API

### DIFF
--- a/docs/src/eval.md
+++ b/docs/src/eval.md
@@ -8,13 +8,34 @@ eval_tree_array(tree::Node{T}, cX::AbstractMatrix{T}, operators::OperatorEnum) w
 ```
 
 Assuming you are only using a single `OperatorEnum`, you can also use
-the following short-hand by using the expression as a function:
+the following shorthand by using the expression as a function:
+
+```
+    (tree::Node)(X::AbstractMatrix{T}, operators::OperatorEnum; turbo::Bool=false)
+
+Evaluate a binary tree (equation) over a given data matrix. The
+operators contain all of the operators used in the tree.
+
+# Arguments
+- `X::AbstractMatrix{T}`: The input data to evaluate the tree on.
+- `operators::OperatorEnum`: The operators used in the tree.
+- `turbo::Bool`: Use `LoopVectorization.@turbo` for faster evaluation.
+
+# Returns
+- `output::AbstractVector{T}`: the result, which is a 1D array.
+    Any NaN, Inf, or other failure during the evaluation will result in the entire
+    output array being set to NaN.
+```
+
+For example,
 
 ```@example
+using DynamicExpressions
+
 operators = OperatorEnum(; binary_operators=[+, -, *], unary_operators=[cos])
 tree = Node(; feature=1) * cos(Node(; feature=2) - 3.2)
 
-tree(X)
+tree([1 2 3; 4 5 6.], operators)
 ```
 
 This is possible because when you call `OperatorEnum`, it automatically re-defines
@@ -32,7 +53,31 @@ The notation is the same for `eval_tree_array`, though it will return `nothing`
 when it can't find a method, and not do any NaN checks:
 
 ```@docs
-    eval_tree_array(tree, cX::AbstractArray, operators::GenericOperatorEnum; throw_errors::Bool=true)
+eval_tree_array(tree::Node, cX::AbstractMatrix, operators::GenericOperatorEnum; throw_errors::Bool=true)
+```
+
+Likewise for the shorthand notation:
+
+```
+    (tree::Node)(X::AbstractMatrix, operators::GenericOperatorEnum; throw_errors::Bool=true)
+
+# Arguments
+- `X::AbstractArray`: The input data to evaluate the tree on.
+- `operators::GenericOperatorEnum`: The operators used in the tree.
+- `throw_errors::Bool=true`: Whether to throw errors
+    if they occur during evaluation. Otherwise,
+    MethodErrors will be caught before they happen and 
+    evaluation will return `nothing`,
+    rather than throwing an error. This is useful in cases
+    where you are unsure if a particular tree is valid or not,
+    and would prefer to work with `nothing` as an output.
+
+# Returns
+- `output`: the result of the evaluation.
+    If evaluation failed, `nothing` will be returned for the first argument.
+    A `false` complete means an operator was called on input types
+    that it was not defined for. You can change this behavior by
+    setting `throw_errors=false`.
 ```
 
 ## Derivatives
@@ -46,7 +91,32 @@ all variables (or, all constants). Both use forward-mode automatic, but use
 
 ```@docs
 eval_diff_tree_array(tree::Node{T}, cX::AbstractMatrix{T}, operators::OperatorEnum, direction::Int) where {T<:Number}
-eval_grad_tree_array(tree::Node{T}, cX::AbstractMatrix{T}, operators::OperatorEnum; variable::Bool=false) where {T<:Number}
+eval_grad_tree_array(tree::Node{T}, cX::AbstractMatrix{T}, operators::OperatorEnum; turbo::Bool=false, variable::Bool=false) where {T<:Number}
+```
+
+You can compute gradients this with shorthand notation as well (which by default computes
+gradients with respect to input matrix, rather than constants).
+
+```
+    (tree::Node{T})'(X::AbstractMatrix{T}, operators::OperatorEnum; turbo::Bool=false, variable::Bool=true)
+
+Compute the forward-mode derivative of an expression, using a similar
+structure and optimization to eval_tree_array. `variable` specifies whether
+we should take derivatives with respect to features (i.e., X), or with respect
+to every constant in the expression.
+
+# Arguments
+- `X::AbstractMatrix{T}`: The data matrix, with each column being a data point.
+- `operators::OperatorEnum`: The operators used to create the `tree`. Note that `operators.enable_autodiff`
+    must be `true`. This is needed to create the derivative operations.
+- `variable::Bool`: Whether to take derivatives with respect to features (i.e., `X` - with `variable=true`),
+    or with respect to every constant in the expression (`variable=false`).
+- `turbo::Bool`: Use `LoopVectorization.@turbo` for faster evaluation.
+
+# Returns
+
+- `(evaluation, gradient, complete)::Tuple{AbstractVector{T}, AbstractMatrix{T}, Bool}`: the normal evaluation,
+    the gradient, and whether the evaluation completed as normal (or encountered a nan or inf).
 ```
 
 Alternatively, you can compute higher-order derivatives by using `ForwardDiff` on

--- a/docs/src/eval.md
+++ b/docs/src/eval.md
@@ -10,7 +10,7 @@ eval_tree_array(tree::Node{T}, cX::AbstractMatrix{T}, operators::OperatorEnum) w
 Assuming you are only using a single `OperatorEnum`, you can also use
 the following short-hand by using the expression as a function:
 
-```julia
+```@example
 operators = OperatorEnum(; binary_operators=[+, -, *], unary_operators=[cos])
 tree = Node(; feature=1) * cos(Node(; feature=2) - 3.2)
 

--- a/src/DynamicExpressions.jl
+++ b/src/DynamicExpressions.jl
@@ -6,6 +6,7 @@ include("Equation.jl")
 include("EquationUtils.jl")
 include("EvaluateEquation.jl")
 include("EvaluateEquationDerivative.jl")
+include("EvaluationHelpers.jl")
 include("InterfaceSymbolicUtils.jl")
 include("SimplifyEquation.jl")
 include("OperatorEnumConstruction.jl")
@@ -31,6 +32,7 @@ using Reexport
     eval_diff_tree_array, eval_grad_tree_array
 @reexport import .InterfaceSymbolicUtilsModule: node_to_symbolic, symbolic_to_node
 @reexport import .SimplifyEquationModule: combine_operators, simplify_tree
+@reexport import .EvaluationHelpersModule
 
 import TOML: parsefile
 

--- a/src/EvaluationHelpers.jl
+++ b/src/EvaluationHelpers.jl
@@ -7,11 +7,48 @@ import ..EvaluateEquationModule: eval_tree_array
 import ..EvaluateEquationDerivativeModule: eval_grad_tree_array
 
 # Evaluation:
+"""
+    (tree::Node)(X::AbstractMatrix{T}, operators::OperatorEnum; turbo::Bool=false)
+
+Evaluate a binary tree (equation) over a given data matrix. The
+operators contain all of the operators used in the tree.
+
+# Arguments
+- `X::AbstractMatrix{T}`: The input data to evaluate the tree on.
+- `operators::OperatorEnum`: The operators used in the tree.
+- `turbo::Bool`: Use `LoopVectorization.@turbo` for faster evaluation.
+
+# Returns
+- `output::AbstractVector{T}`: the result, which is a 1D array.
+    Any NaN, Inf, or other failure during the evaluation will result in the entire
+    output array being set to NaN.
+"""
 function (tree::Node)(X, operators::OperatorEnum; kws...)
     out, did_finish = eval_tree_array(tree, X, operators; kws...)
     !did_finish && (out .= convert(eltype(out), NaN))
     return out
 end
+"""
+    (tree::Node)(X::AbstractMatrix, operators::GenericOperatorEnum; throw_errors::Bool=true)
+
+# Arguments
+- `X::AbstractArray`: The input data to evaluate the tree on.
+- `operators::GenericOperatorEnum`: The operators used in the tree.
+- `throw_errors::Bool=true`: Whether to throw errors
+    if they occur during evaluation. Otherwise,
+    MethodErrors will be caught before they happen and 
+    evaluation will return `nothing`,
+    rather than throwing an error. This is useful in cases
+    where you are unsure if a particular tree is valid or not,
+    and would prefer to work with `nothing` as an output.
+
+# Returns
+- `output`: the result of the evaluation.
+    If evaluation failed, `nothing` will be returned for the first argument.
+    A `false` complete means an operator was called on input types
+    that it was not defined for. You can change this behavior by
+    setting `throw_errors=false`.
+"""
 function (tree::Node)(X, operators::GenericOperatorEnum; kws...)
     out, did_finish = eval_tree_array(tree, X, operators; kws...)
     !did_finish && return nothing
@@ -37,6 +74,28 @@ function _grad_evaluator(tree::Node, X; kws...)
     ## into a depwarn
     @error "The `tree'(X; kws...)` syntax is deprecated. Use `tree'(X, operators; kws...)` instead."
 end
+
+"""
+    (tree::Node{T})'(X::AbstractMatrix{T}, operators::OperatorEnum; turbo::Bool=false, variable::Bool=true)
+
+Compute the forward-mode derivative of an expression, using a similar
+structure and optimization to eval_tree_array. `variable` specifies whether
+we should take derivatives with respect to features (i.e., X), or with respect
+to every constant in the expression.
+
+# Arguments
+- `X::AbstractMatrix{T}`: The data matrix, with each column being a data point.
+- `operators::OperatorEnum`: The operators used to create the `tree`. Note that `operators.enable_autodiff`
+    must be `true`. This is needed to create the derivative operations.
+- `variable::Bool`: Whether to take derivatives with respect to features (i.e., `X` - with `variable=true`),
+    or with respect to every constant in the expression (`variable=false`).
+- `turbo::Bool`: Use `LoopVectorization.@turbo` for faster evaluation.
+
+# Returns
+
+- `(evaluation, gradient, complete)::Tuple{AbstractVector{T}, AbstractMatrix{T}, Bool}`: the normal evaluation,
+    the gradient, and whether the evaluation completed as normal (or encountered a nan or inf).
+"""
 Base.adjoint(tree::Node) = ((args...; kws...) -> _grad_evaluator(tree, args...; kws...))
 
 end

--- a/src/EvaluationHelpers.jl
+++ b/src/EvaluationHelpers.jl
@@ -18,6 +18,8 @@ function (tree::Node)(X, operators::GenericOperatorEnum; kws...)
     return out
 end
 function (tree::Node)(X; kws...)
+    ## This will be overwritten by OperatorEnumConstructionModule, and turned
+    ## into a depwarn.
     @error "The `tree(X; kws...)` syntax is deprecated. Use `tree(X, operators; kws...)` instead."
 end
 
@@ -31,6 +33,8 @@ function _grad_evaluator(tree::Node, X, operators::GenericOperatorEnum; kws...)
     @error "Gradients are not implemented for `GenericOperatorEnum`."
 end
 function _grad_evaluator(tree::Node, X; kws...)
+    ## This will be overwritten by OperatorEnumConstructionModule, and turned
+    ## into a depwarn
     @error "The `tree'(X; kws...)` syntax is deprecated. Use `tree'(X, operators; kws...)` instead."
 end
 Base.adjoint(tree::Node) = ((args...; kws...) -> _grad_evaluator(tree, args...; kws...))

--- a/src/EvaluationHelpers.jl
+++ b/src/EvaluationHelpers.jl
@@ -62,7 +62,9 @@ end
 
 # Gradients:
 function _grad_evaluator(tree::Node, X, operators::OperatorEnum; variable=true, kws...)
-    _, grad, did_complete = eval_grad_tree_array(tree, X, operators; variable=variable, kws...)
+    _, grad, did_complete = eval_grad_tree_array(
+        tree, X, operators; variable=variable, kws...
+    )
     !did_complete && (grad .= convert(eltype(grad), NaN))
     return grad
 end

--- a/src/EvaluationHelpers.jl
+++ b/src/EvaluationHelpers.jl
@@ -57,7 +57,7 @@ end
 function (tree::Node)(X; kws...)
     ## This will be overwritten by OperatorEnumConstructionModule, and turned
     ## into a depwarn.
-    @error "The `tree(X; kws...)` syntax is deprecated. Use `tree(X, operators; kws...)` instead."
+    error("The `tree(X; kws...)` syntax is deprecated. Use `tree(X, operators; kws...)` instead.")
 end
 
 # Gradients:
@@ -69,12 +69,12 @@ function _grad_evaluator(tree::Node, X, operators::OperatorEnum; variable=true, 
     return grad
 end
 function _grad_evaluator(tree::Node, X, operators::GenericOperatorEnum; kws...)
-    @error "Gradients are not implemented for `GenericOperatorEnum`."
+    error("Gradients are not implemented for `GenericOperatorEnum`.")
 end
 function _grad_evaluator(tree::Node, X; kws...)
     ## This will be overwritten by OperatorEnumConstructionModule, and turned
     ## into a depwarn
-    @error "The `tree'(X; kws...)` syntax is deprecated. Use `tree'(X, operators; kws...)` instead."
+    error("The `tree'(X; kws...)` syntax is deprecated. Use `tree'(X, operators; kws...)` instead.")
 end
 
 """

--- a/src/EvaluationHelpers.jl
+++ b/src/EvaluationHelpers.jl
@@ -61,8 +61,8 @@ function (tree::Node)(X; kws...)
 end
 
 # Gradients:
-function _grad_evaluator(tree::Node, X, operators::OperatorEnum; kws...)
-    _, grad, did_complete = eval_grad_tree_array(tree, X, operators; variable=true, kws...)
+function _grad_evaluator(tree::Node, X, operators::OperatorEnum; variable=true, kws...)
+    _, grad, did_complete = eval_grad_tree_array(tree, X, operators; variable=variable, kws...)
     !did_complete && (grad .= convert(eltype(grad), NaN))
     return grad
 end

--- a/src/EvaluationHelpers.jl
+++ b/src/EvaluationHelpers.jl
@@ -1,0 +1,38 @@
+module EvaluationHelpersModule
+
+import Base: adjoint
+import ..OperatorEnumModule: AbstractOperatorEnum, OperatorEnum, GenericOperatorEnum
+import ..EquationModule: Node
+import ..EvaluateEquationModule: eval_tree_array
+import ..EvaluateEquationDerivativeModule: eval_grad_tree_array
+
+# Evaluation:
+function (tree::Node)(X, operators::OperatorEnum; kws...)
+    out, did_finish = eval_tree_array(tree, X, operators; kws...)
+    !did_finish && (out .= convert(eltype(out), NaN))
+    return out
+end
+function (tree::Node)(X, operators::GenericOperatorEnum; kws...)
+    out, did_finish = eval_tree_array(tree, X, operators; kws...)
+    !did_finish && return nothing
+    return out
+end
+function (tree::Node)(X; kws...)
+    @error "The `tree(X; kws...)` syntax is deprecated. Use `tree(X, operators; kws...)` instead."
+end
+
+# Gradients:
+function _grad_evaluator(tree::Node, X, operators::OperatorEnum; kws...)
+    _, grad, did_complete = eval_grad_tree_array(tree, X, operators; variable=true, kws...)
+    !did_complete && (grad .= convert(eltype(grad), NaN))
+    return grad
+end
+function _grad_evaluator(tree::Node, X, operators::GenericOperatorEnum; kws...)
+    @error "Gradients are not implemented for `GenericOperatorEnum`."
+end
+function _grad_evaluator(tree::Node, X; kws...)
+    @error "The `tree'(X; kws...)` syntax is deprecated. Use `tree'(X, operators; kws...)` instead."
+end
+Base.adjoint(tree::Node) = ((args...; kws...) -> _grad_evaluator(tree, args...; kws...))
+
+end

--- a/src/EvaluationHelpers.jl
+++ b/src/EvaluationHelpers.jl
@@ -57,7 +57,9 @@ end
 function (tree::Node)(X; kws...)
     ## This will be overwritten by OperatorEnumConstructionModule, and turned
     ## into a depwarn.
-    error("The `tree(X; kws...)` syntax is deprecated. Use `tree(X, operators; kws...)` instead.")
+    return error(
+        "The `tree(X; kws...)` syntax is deprecated. Use `tree(X, operators; kws...)` instead.",
+    )
 end
 
 # Gradients:
@@ -69,12 +71,14 @@ function _grad_evaluator(tree::Node, X, operators::OperatorEnum; variable=true, 
     return grad
 end
 function _grad_evaluator(tree::Node, X, operators::GenericOperatorEnum; kws...)
-    error("Gradients are not implemented for `GenericOperatorEnum`.")
+    return error("Gradients are not implemented for `GenericOperatorEnum`.")
 end
 function _grad_evaluator(tree::Node, X; kws...)
     ## This will be overwritten by OperatorEnumConstructionModule, and turned
     ## into a depwarn
-    error("The `tree'(X; kws...)` syntax is deprecated. Use `tree'(X, operators; kws...)` instead.")
+    return error(
+        "The `tree'(X; kws...)` syntax is deprecated. Use `tree'(X, operators; kws...)` instead.",
+    )
 end
 
 """

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -42,7 +42,7 @@ function create_evaluation_helpers!(operators::GenericOperatorEnum)
             return tree(X, $operators; kws...)
         end
         function _grad_evaluator(tree::Node, X; kws...)
-            @error "Gradients are not implemented for `GenericOperatorEnum`."
+            return error("Gradients are not implemented for `GenericOperatorEnum`.")
         end
     end
 end

--- a/test/test_custom_operators.jl
+++ b/test/test_custom_operators.jl
@@ -21,7 +21,7 @@ tree = op1(op2(x1, x2), op3(x1))
 @test repr(tree) == "op1(op2(x1, x2), op3(x1))"
 # Test evaluation:
 X = randn(MersenneTwister(0), Float32, 2, 10);
-@test tree(X) ≈ ((x1, x2) -> op1(op2(x1, x2), op3(x1))).(X[1, :], X[2, :])
+@test tree(X, operators) ≈ ((x1, x2) -> op1(op2(x1, x2), op3(x1))).(X[1, :], X[2, :])
 
 # Now, test that we can work with operators defined in modules
 module A
@@ -47,7 +47,7 @@ function create_and_eval_tree()
     tree = my_func_a(my_func_a(x2, 0.2), my_func_b(x1))
     func = (x1, x2) -> my_func_a(my_func_a(x2, 0.2), my_func_b(x1))
     X = randn(MersenneTwister(0), 2, 20)
-    return tree(X), func.(X[1, :], X[2, :])
+    return tree(X, operators), func.(X[1, :], X[2, :])
 end
 
 end
@@ -74,4 +74,7 @@ c1 = Node(Float64; val=0.2)
 tree = my_func_c(my_func_c(x2, 0.2), my_func_d(x1))
 func = (x1, x2) -> my_func_c(my_func_c(x2, 0.2), my_func_d(x1))
 X = randn(MersenneTwister(0), 2, 20)
+@test tree(X, operators) ≈ func.(X[1, :], X[2, :])
+
+# Test deprecated implicit syntax:
 @test tree(X) ≈ func.(X[1, :], X[2, :])

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -88,12 +88,15 @@ for type in [Float16, Float32, Float64], turbo in [true, false]
                     i in 1:nfeatures
                 ],
             )'
-        predicted_grad3 = tree'(X)
+        predicted_grad3 = tree'(X, operators; turbo=turbo)
+        # Test deprecated syntax:
+        predicted_grad4 = tree'(X; turbo=turbo)
 
         # Print largest difference between predicted_grad, true_grad:
         @test array_test(predicted_grad, true_grad)
         @test array_test(predicted_grad2, true_grad)
         @test array_test(predicted_grad3, true_grad)
+        @test array_test(predicted_grad4, true_grad)
 
         # Make sure that the array_test actually works:
         @test !array_test(predicted_grad .* 0, true_grad)

--- a/test/test_error_handling.jl
+++ b/test/test_error_handling.jl
@@ -48,6 +48,6 @@ try
     @test false
 catch e
     @test isa(e, ErrorException)
-    expected_error_msg = "The `tree'(X; kws...)` syntax is deprecated"
+    expected_error_msg = "Gradients are not implemented"
     @test occursin(expected_error_msg, e.msg)
 end

--- a/test/test_error_handling.jl
+++ b/test/test_error_handling.jl
@@ -1,6 +1,27 @@
 using DynamicExpressions
 using Test
 
+# Before defining OperatorEnum, calling the implicit (deprecated)
+# syntax should fail:
+tree = Node(; feature=1)
+try
+    tree([1.0 2.0]')
+    @test false
+catch e
+    @test isa(e, ErrorException)
+    expected_error_msg = "The `tree(X; kws...)` syntax is deprecated"
+    @test occursin(expected_error_msg, e.msg)
+end
+
+try
+    tree'([1.0 2.0]')
+    @test false
+catch e
+    @test isa(e, ErrorException)
+    expected_error_msg = "The `tree'(X; kws...)` syntax is deprecated"
+    @test occursin(expected_error_msg, e.msg)
+end
+
 # Test that we generate errors:
 baseT = Float64
 T = Union{baseT,Vector{baseT},Matrix{baseT}}
@@ -33,11 +54,11 @@ output, flag = eval_tree_array(
 
 # Default is to catch errors:
 try
-    tree([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    tree([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], operators)
     @test false
 catch e
     @test isa(e, ErrorException)
 end
 
 # But can be overrided:
-output = tree([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]; throw_errors=false)
+output = tree([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], operators; throw_errors=false)

--- a/test/test_error_handling.jl
+++ b/test/test_error_handling.jl
@@ -1,27 +1,6 @@
 using DynamicExpressions
 using Test
 
-# Before defining OperatorEnum, calling the implicit (deprecated)
-# syntax should fail:
-tree = Node(; feature=1)
-try
-    tree([1.0 2.0]')
-    @test false
-catch e
-    @test isa(e, ErrorException)
-    expected_error_msg = "The `tree(X; kws...)` syntax is deprecated"
-    @test occursin(expected_error_msg, e.msg)
-end
-
-try
-    tree'([1.0 2.0]')
-    @test false
-catch e
-    @test isa(e, ErrorException)
-    expected_error_msg = "The `tree'(X; kws...)` syntax is deprecated"
-    @test occursin(expected_error_msg, e.msg)
-end
-
 # Test that we generate errors:
 baseT = Float64
 T = Union{baseT,Vector{baseT},Matrix{baseT}}
@@ -62,3 +41,13 @@ end
 
 # But can be overrided:
 output = tree([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], operators; throw_errors=false)
+
+# Gradients are undefined for GenericOperatorEnum:
+try
+    tree'([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], operators)
+    @test false
+catch e
+    @test isa(e, ErrorException)
+    expected_error_msg = "The `tree'(X; kws...)` syntax is deprecated"
+    @test occursin(expected_error_msg, e.msg)
+end

--- a/test/test_evaluation.jl
+++ b/test/test_evaluation.jl
@@ -69,6 +69,9 @@ for turbo in [false, true],
 
     zero_tolerance = (T <: Union{Float16,Complex} ? 1e-4 : 1e-6)
     @test all(abs.(test_y .- true_y) / N .< zero_tolerance)
+
+    test_y_helper = tree(X, operators; turbo=turbo)
+    @test all(test_y .== test_y_helper)
 end
 
 for turbo in [false, true], T in [Float16, Float32, Float64, ComplexF32, ComplexF64]
@@ -110,7 +113,7 @@ for turbo in [false, true], T in [Float16, Float32, Float64, ComplexF32, Complex
     x1 = Node(T; feature=1)
     tree = sin(x1 / 0.0)
     X = randn(Float32, 3, 10)
-    @test isnan(tree(X; turbo=turbo)[1])
+    @test isnan(tree(X, operators; turbo=turbo)[1])
 end
 
 # Check if julia version >= 1.7:
@@ -124,7 +127,7 @@ if VERSION >= v"1.7"
     X = randn(Float32, 10)
     local stack
     try
-        tree(X)[1]
+        tree(X, operators)[1]
         @test false
     catch e
         @test e isa ErrorException
@@ -137,10 +140,10 @@ if VERSION >= v"1.7"
 
     # If a method is not defined, we should get a nothing:
     X = randn(Float32, 1, 10)
-    @test tree(X; throw_errors=false) === nothing
+    @test tree(X, operators; throw_errors=false) === nothing
     # or a MethodError:
     try
-        tree(X; throw_errors=true)
+        tree(X, operators; throw_errors=true)
         @test false
     catch e
         @test e isa ErrorException

--- a/test/test_generic_operators.jl
+++ b/test/test_generic_operators.jl
@@ -7,4 +7,4 @@ operators = GenericOperatorEnum(; binary_operators=(*,))
 
 x1, x2, x3 = [Node(String; feature=i) for i in 1:3]
 tree = x1 * " " * "World!"
-@test tree(["Hello"]) == "Hello World!"
+@test tree(["Hello"], operators) == "Hello World!"

--- a/test/test_tensor_operators.jl
+++ b/test/test_tensor_operators.jl
@@ -17,19 +17,19 @@ X = [[2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]
 
 tree = Node(1, c1, x2)
 @test repr(tree) == "vec_add([1.0, 2.0, 3.0], x2)"
-@test tree(X) == [4.0, 5.0, 6.0]
+@test tree(X, operators) == [4.0, 5.0, 6.0]
 tree = Node(1, x1, c1)
 @test repr(tree) == "vec_add(x1, [1.0, 2.0, 3.0])"
-@test tree(X) == [3.0, 4.0, 5.0]
+@test tree(X, operators) == [3.0, 4.0, 5.0]
 
 # Try same things, but with constructors:
 @extend_operators operators
 tree = vec_add(c1, x2)
 @test repr(tree) == "vec_add([1.0, 2.0, 3.0], x2)"
-@test tree(X) == [4.0, 5.0, 6.0]
+@test tree(X, operators) == [4.0, 5.0, 6.0]
 tree = vec_add(x1, c1)
 @test repr(tree) == "vec_add(x1, [1.0, 2.0, 3.0])"
-@test tree(X) == [3.0, 4.0, 5.0]
+@test tree(X, operators) == [3.0, 4.0, 5.0]
 
 # Also test unary operators:
 function vec_square(x)
@@ -40,11 +40,11 @@ operators = GenericOperatorEnum(; binary_operators=[vec_add], unary_operators=[v
 @extend_operators operators
 tree = Node(1, c1)
 @test repr(tree) == "vec_square([1.0, 2.0, 3.0])"
-@test tree(X) == [1.0, 4.0, 9.0]
+@test tree(X, operators) == [1.0, 4.0, 9.0]
 @test vec_square(c1).val == [1.0, 4.0, 9.0]
 tree = Node(1, Node(1, c1), x1)
 @test repr(tree) == "vec_add(vec_square([1.0, 2.0, 3.0]), x1)"
-@test tree(X) == [3.0, 6.0, 11.0]
+@test tree(X, operators) == [3.0, 6.0, 11.0]
 @test (vec_add(vec_square(c1), x1))(X) == [3.0, 6.0, 11.0]
 
 # Also test mixed scalar and floats:
@@ -52,5 +52,5 @@ c2 = Node(T; val=2.0)
 @test repr(c2) == "2.0"
 tree = Node(1, Node(1, c1, x1), c2)
 @test repr(tree) == "vec_add(vec_add([1.0, 2.0, 3.0], x1), 2.0)"
-tree(X)
-@test tree(X) == [5.0, 6.0, 7.0]
+tree(X, operators)
+@test tree(X, operators) == [5.0, 6.0, 7.0]

--- a/test/test_tensor_operators.jl
+++ b/test/test_tensor_operators.jl
@@ -52,5 +52,4 @@ c2 = Node(T; val=2.0)
 @test repr(c2) == "2.0"
 tree = Node(1, Node(1, c1, x1), c2)
 @test repr(tree) == "vec_add(vec_add([1.0, 2.0, 3.0], x1), 2.0)"
-tree(X, operators)
 @test tree(X, operators) == [5.0, 6.0, 7.0]

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -1,5 +1,31 @@
 using SafeTestsets
 
+@safetestset "Initial error handling test" begin
+    using DynamicExpressions
+    using Test
+
+    # Before defining OperatorEnum, calling the implicit (deprecated)
+    # syntax should fail:
+    tree = Node(; feature=1)
+    try
+        tree([1.0 2.0]')
+        @test false
+    catch e
+        @test isa(e, ErrorException)
+        expected_error_msg = "The `tree(X; kws...)` syntax is deprecated"
+        @test occursin(expected_error_msg, e.msg)
+    end
+
+    try
+        tree'([1.0 2.0]')
+        @test false
+    catch e
+        @test isa(e, ErrorException)
+        expected_error_msg = ""
+        @test occursin(expected_error_msg, e.msg)
+    end
+end
+
 @safetestset "Test tree construction and scoring" begin
     include("test_tree_construction.jl")
 end

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -21,7 +21,7 @@ using SafeTestsets
         @test false
     catch e
         @test isa(e, ErrorException)
-        expected_error_msg = ""
+        expected_error_msg = "The `tree'(X; kws...)` syntax is deprecated"
         @test occursin(expected_error_msg, e.msg)
     end
 end


### PR DESCRIPTION
Taking @Moelf's suggestion in #21, this PR deprecates (softly, using `Base.depwarn`) the functor syntax `tree(X)`, which implicitly uses the last `OperatorEnum()` that was created.

This PR replaces it with the explicit functor syntax: `tree(X, operators)`. Likewise for gradients: `tree'(X, operators)`.

@Moelf do you think you could review?

Thanks!
Miles

---

fixes #21 