### PR TITLE
Preserve container types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,8 @@ julia = "1.6"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SafeTestsets", "SpecialFunctions", "ForwardDiff"]
+test = ["Test", "SafeTestsets", "SpecialFunctions", "ForwardDiff", "StaticArrays"]

--- a/src/EvaluateEquationDerivative.jl
+++ b/src/EvaluateEquationDerivative.jl
@@ -294,7 +294,11 @@ function grad_deg0_eval(
 )::Tuple{AbstractVector{T},AbstractMatrix{T},Bool} where {T<:Number,variable,n_gradients}
     const_part = deg0_eval(tree, cX)[1]
 
-    zero_mat = hcat((fill_similar(zero(T), cX, axes(cX, 2)) for _ in 1:n_gradients)...)'
+    zero_mat = if typeof(cX) <: Array
+        zeros(T, n_gradients, size(cX, 2))
+    else
+        hcat((fill_similar(zero(T), cX, axes(cX, 2)) for _ in 1:n_gradients)...)'
+    end
 
     if variable == tree.constant
         return (const_part, zero_mat, true)

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -75,7 +75,7 @@ end
 
 # Fastest way to check for NaN in an array.
 # (due to optimizations in sum())
-is_bad_array(array) = !isfinite(sum(array))
+is_bad_array(array) = !(isempty(array) || isfinite(sum(array)))
 isgood(x::T) where {T<:Number} = !(isnan(x) || !isfinite(x))
 isgood(x) = true
 isbad(x) = !isgood(x)

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -155,4 +155,6 @@ function _add_idmap_to_call(def::Expr, id_map::Expr)
     return Expr(:call, def.args[1], def.args[2:end]..., id_map)
 end
 
+@inline fill_similar(value, array, args...) = fill!(similar(array, args...), value)
+
 end

--- a/test/test_container_preserved.jl
+++ b/test/test_container_preserved.jl
@@ -1,0 +1,17 @@
+using DynamicExpressions
+using StaticArrays
+using Test
+
+@testset "StaticArrays type preserved" begin
+    X = MMatrix{3,10}(randn(3, 10))
+    operators = OperatorEnum(; binary_operators=[+, -, *, /], unary_operators=[cos, sin])
+    x1, x2, x3 = (i -> Node(Float64; feature=i)).(1:3)
+    tree = cos(x1 * 5.2 - 0.9) * x3 + x2 * x2 - 2.2
+    y = tree(X, operators)
+    @test typeof(y) == MVector{10,Float64}
+
+    X .= NaN
+    tree = cos(x1 * 5.2 - 0.9) * x3 + x2 * x2 - 2.2
+    y = tree(X, operators)
+    @test typeof(y) == MVector{10,Float64}
+end

--- a/test/test_container_preserved.jl
+++ b/test/test_container_preserved.jl
@@ -3,15 +3,33 @@ using StaticArrays
 using Test
 
 @testset "StaticArrays type preserved" begin
-    X = MMatrix{3,10}(randn(3, 10))
-    operators = OperatorEnum(; binary_operators=[+, -, *, /], unary_operators=[cos, sin])
-    x1, x2, x3 = (i -> Node(Float64; feature=i)).(1:3)
-    tree = cos(x1 * 5.2 - 0.9) * x3 + x2 * x2 - 2.2
-    y = tree(X, operators)
-    @test typeof(y) == MVector{10,Float64}
+    for T in (Float32, Float64)
+        X = MMatrix{3,10}(randn(T, 3, 10))
+        operators = OperatorEnum(;
+            binary_operators=[+, -, *, /], unary_operators=[cos, sin], enable_autodiff=true
+        )
+        x1, x2, x3 = (i -> Node(; feature=i)).(1:3)
+        tree = cos(x1 * 5.2 - 0.9) * x3 + x2 * x2 - 2.2 * x1 + 1.0
+        tree = convert(Node{T}, tree)
 
-    X .= NaN
-    tree = cos(x1 * 5.2 - 0.9) * x3 + x2 * x2 - 2.2
-    y = tree(X, operators)
-    @test typeof(y) == MVector{10,Float64}
+        y = tree(X, operators)
+        @test typeof(y) == MVector{10,T}
+
+        dy = tree'(X, operators)
+        @test typeof(dy) == MMatrix{3,10,T,30}
+
+        dy = tree'(X, operators; variable=false)
+        @test typeof(dy) == MMatrix{4,10,T,40}
+
+        # Even with NaNs:
+        X .= T(NaN)
+        y = tree(X, operators)
+        @test typeof(y) == MVector{10,T}
+
+        dy = tree'(X, operators)
+        @test typeof(dy) == MMatrix{3,10,T,30}
+
+        dy = tree'(X, operators; variable=false)
+        @test typeof(dy) == MMatrix{4,10,T,40}
+    end
 end

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -97,3 +97,7 @@ end
 @safetestset "Test Base" begin
     include("test_base.jl")
 end
+
+@safetestset "Test containers preserved" begin
+    include("test_container_preserved.jl")
+end


### PR DESCRIPTION
Right now the evaluation code seems to convert all container types to `Vector` and `Matrix`.

This fixes it. Now you can pass in a StaticArrays object, and all calculations will be performed with the same StaticArrays.