### PR TITLE
Lazily load Zygote.jl for faster TTL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [extensions]
 DynamicExpressionsSymbolicUtilsExt = "SymbolicUtils"
+DynamicExpressionsZygoteExt = "Zygote"
 
 [compat]
 Compat = "3.37, 4"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.9.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+LazyModules = "8cdb02fc-e678-4876-92c5-9defec4f444e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Compat = "3.37, 4"
+LazyModules = "0.3"
 LoopVectorization = "0.12"
 MacroTools = "0.4, 0.5"
 PrecompileTools = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.9.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-LazyModules = "8cdb02fc-e678-4876-92c5-9defec4f444e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
@@ -17,9 +16,14 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
+[weakdeps]
+SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
+
+[extensions]
+DynamicExpressionsSymbolicUtilsExt = "SymbolicUtils"
+
 [compat]
 Compat = "3.37, 4"
-LazyModules = "0.3"
 LoopVectorization = "0.12"
 MacroTools = "0.4, 0.5"
 PrecompileTools = "1"
@@ -28,9 +32,6 @@ Requires = "1.0, 1.1, 1.2, 1.3"
 SymbolicUtils = "0.19, ^1.0.5"
 Zygote = "0.6"
 julia = "1.6"
-
-[extensions]
-DynamicExpressionsSymbolicUtilsExt = "SymbolicUtils"
 
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -42,6 +43,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "SafeTestsets", "SpecialFunctions", "ForwardDiff", "StaticArrays", "SymbolicUtils"]
-
-[weakdeps]
-SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"

--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [weakdeps]
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [extensions]
 DynamicExpressionsSymbolicUtilsExt = "SymbolicUtils"

--- a/ext/DynamicExpressionsZygoteExt.jl
+++ b/ext/DynamicExpressionsZygoteExt.jl
@@ -1,4 +1,12 @@
-import Zygote: gradient
+module DynamicExpressionsZygoteExt
+
+if isdefined(Base, :get_extension)
+    import Zygote: gradient
+    import DynamicExpressions: generate_diff_operators
+else
+    import ..Zygote: gradient
+    import ..DynamicExpressions: generate_diff_operators
+end
 
 make_diff_bin(op) = (x, y) -> gradient(op, x, y)
 make_diff_una(op) = x -> gradient(op, x)[1]
@@ -18,4 +26,6 @@ function generate_diff_operators(
         push!(diff_una, diff_op)
     end
     return diff_bin, diff_una
+end
+
 end

--- a/src/DynamicExpressions.jl
+++ b/src/DynamicExpressions.jl
@@ -3,13 +3,13 @@ module DynamicExpressions
 include("Utils.jl")
 include("OperatorEnum.jl")
 include("Equation.jl")
+include("ExtensionInterface.jl")
 include("EquationUtils.jl")
 include("EvaluateEquation.jl")
 include("EvaluateEquationDerivative.jl")
 include("EvaluationHelpers.jl")
 include("SimplifyEquation.jl")
 include("OperatorEnumConstruction.jl")
-include("ExtensionInterface.jl")
 
 import Requires: @init, @require
 import Reexport: @reexport
@@ -27,13 +27,14 @@ import Reexport: @reexport
     set_constants!
 @reexport import .OperatorEnumModule: AbstractOperatorEnum
 @reexport import .OperatorEnumConstructionModule:
-    OperatorEnum, GenericOperatorEnum, @extend_operators, generate_diff_operators
+    OperatorEnum, GenericOperatorEnum, @extend_operators
 @reexport import .EvaluateEquationModule: eval_tree_array, differentiable_eval_tree_array
 @reexport import .EvaluateEquationDerivativeModule:
     eval_diff_tree_array, eval_grad_tree_array
 @reexport import .SimplifyEquationModule: combine_operators, simplify_tree
 @reexport import .EvaluationHelpersModule
-@reexport import .ExtensionInterfaceModule: node_to_symbolic, symbolic_to_node
+@reexport import .ExtensionInterfaceModule:
+    node_to_symbolic, symbolic_to_node, generate_diff_operators
 
 #! format: off
 if !isdefined(Base, :get_extension)

--- a/src/DynamicExpressions.jl
+++ b/src/DynamicExpressions.jl
@@ -27,7 +27,7 @@ import Reexport: @reexport
     set_constants!
 @reexport import .OperatorEnumModule: AbstractOperatorEnum
 @reexport import .OperatorEnumConstructionModule:
-    OperatorEnum, GenericOperatorEnum, @extend_operators
+    OperatorEnum, GenericOperatorEnum, @extend_operators, generate_diff_operators
 @reexport import .EvaluateEquationModule: eval_tree_array, differentiable_eval_tree_array
 @reexport import .EvaluateEquationDerivativeModule:
     eval_diff_tree_array, eval_grad_tree_array
@@ -38,6 +38,7 @@ import Reexport: @reexport
 #! format: off
 if !isdefined(Base, :get_extension)
     @init @require SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b" include("../ext/DynamicExpressionsSymbolicUtilsExt.jl")
+    @init @require Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f" include("../ext/DynamicExpressionsZygoteExt.jl")
 end
 #! format: on
 

--- a/src/EvaluateEquation.jl
+++ b/src/EvaluateEquation.jl
@@ -142,7 +142,7 @@ end
 function deg2_eval(
     cumulator_l::AbstractVector{T}, cumulator_r::AbstractVector{T}, op::F, ::Val{turbo}
 )::Tuple{AbstractVector{T},Bool} where {T<:Number,F,turbo}
-    @maybe_turbo turbo for j in indices(cumulator_l)
+    @maybe_turbo turbo for j in axes(cumulator_l, 1)
         x = op(cumulator_l[j], cumulator_r[j])::T
         cumulator_l[j] = x
     end
@@ -152,7 +152,7 @@ end
 function deg1_eval(
     cumulator::AbstractVector{T}, op::F, ::Val{turbo}
 )::Tuple{AbstractVector{T},Bool} where {T<:Number,F,turbo}
-    @maybe_turbo turbo for j in indices(cumulator)
+    @maybe_turbo turbo for j in axes(cumulator, 1)
         x = op(cumulator[j])::T
         cumulator[j] = x
     end
@@ -187,7 +187,7 @@ function deg1_l2_ll0_lr0_eval(
         @return_on_check val_ll cX
         feature_lr = tree.l.r.feature
         cumulator = similar(cX, axes(cX, 2))
-        @maybe_turbo turbo for j in indices((cX, cumulator), (2, 1))
+        @maybe_turbo turbo for j in axes(cumulator, 1)
             x_l = op_l(val_ll, cX[feature_lr, j])::T
             x = isfinite(x_l) ? op(x_l)::T : T(Inf)
             cumulator[j] = x
@@ -198,7 +198,7 @@ function deg1_l2_ll0_lr0_eval(
         val_lr = tree.l.r.val::T
         @return_on_check val_lr cX
         cumulator = similar(cX, axes(cX, 2))
-        @maybe_turbo turbo for j in indices((cX, cumulator), (2, 1))
+        @maybe_turbo turbo for j in axes(cumulator, 1)
             x_l = op_l(cX[feature_ll, j], val_lr)::T
             x = isfinite(x_l) ? op(x_l)::T : T(Inf)
             cumulator[j] = x
@@ -208,7 +208,7 @@ function deg1_l2_ll0_lr0_eval(
         feature_ll = tree.l.l.feature
         feature_lr = tree.l.r.feature
         cumulator = similar(cX, axes(cX, 2))
-        @maybe_turbo turbo for j in indices((cX, cumulator), (2, 1))
+        @maybe_turbo turbo for j in axes(cumulator, 1)
             x_l = op_l(cX[feature_ll, j], cX[feature_lr, j])::T
             x = isfinite(x_l) ? op(x_l)::T : T(Inf)
             cumulator[j] = x
@@ -232,7 +232,7 @@ function deg1_l1_ll0_eval(
     else
         feature_ll = tree.l.l.feature
         cumulator = similar(cX, axes(cX, 2))
-        @maybe_turbo turbo for j in indices((cX, cumulator), (2, 1))
+        @maybe_turbo turbo for j in axes(cumulator, 1)
             x_l = op_l(cX[feature_ll, j])::T
             x = isfinite(x_l) ? op(x_l)::T : T(Inf)
             cumulator[j] = x
@@ -258,7 +258,7 @@ function deg2_l0_r0_eval(
         val_l = tree.l.val::T
         @return_on_check val_l cX
         feature_r = tree.r.feature
-        @maybe_turbo turbo for j in indices((cX, cumulator), (2, 1))
+        @maybe_turbo turbo for j in axes(cumulator, 1)
             x = op(val_l, cX[feature_r, j])::T
             cumulator[j] = x
         end
@@ -267,7 +267,7 @@ function deg2_l0_r0_eval(
         feature_l = tree.l.feature
         val_r = tree.r.val::T
         @return_on_check val_r cX
-        @maybe_turbo turbo for j in indices((cX, cumulator), (2, 1))
+        @maybe_turbo turbo for j in axes(cumulator, 1)
             x = op(cX[feature_l, j], val_r)::T
             cumulator[j] = x
         end
@@ -275,7 +275,7 @@ function deg2_l0_r0_eval(
         cumulator = similar(cX, axes(cX, 2))
         feature_l = tree.l.feature
         feature_r = tree.r.feature
-        @maybe_turbo turbo for j in indices((cX, cumulator), (2, 1))
+        @maybe_turbo turbo for j in axes(cumulator, 1)
             x = op(cX[feature_l, j], cX[feature_r, j])::T
             cumulator[j] = x
         end
@@ -290,13 +290,13 @@ function deg2_l0_eval(
     if tree.l.constant
         val = tree.l.val::T
         @return_on_check val cX
-        @maybe_turbo turbo for j in indices(cumulator)
+        @maybe_turbo turbo for j in axes(cumulator, 1)
             x = op(val, cumulator[j])::T
             cumulator[j] = x
         end
     else
         feature = tree.l.feature
-        @maybe_turbo turbo for j in indices((cX, cumulator), (2, 1))
+        @maybe_turbo turbo for j in axes(cumulator, 1)
             x = op(cX[feature, j], cumulator[j])::T
             cumulator[j] = x
         end
@@ -311,13 +311,13 @@ function deg2_r0_eval(
     if tree.r.constant
         val = tree.r.val::T
         @return_on_check val cX
-        @maybe_turbo turbo for j in indices(cumulator)
+        @maybe_turbo turbo for j in axes(cumulator, 1)
             x = op(cumulator[j], val)::T
             cumulator[j] = x
         end
     else
         feature = tree.r.feature
-        @maybe_turbo turbo for j in indices((cX, cumulator), (2, 1))
+        @maybe_turbo turbo for j in axes(cumulator, 1)
             x = op(cumulator[j], cX[feature, j])::T
             cumulator[j] = x
         end

--- a/src/EvaluateEquationDerivative.jl
+++ b/src/EvaluateEquationDerivative.jl
@@ -126,7 +126,7 @@ function diff_deg1_eval(
     @return_on_false2 complete cumulator dcumulator
 
     # TODO - add type assertions to get better speed:
-    @maybe_turbo turbo for j in indices((cumulator, dcumulator))
+    @maybe_turbo turbo for j in axes(cumulator, 1)
         x = op(cumulator[j])::T
         dx = diff_op(cumulator[j])::T * dcumulator[j]
 
@@ -154,7 +154,7 @@ function diff_deg2_eval(
     )
     @return_on_false2 complete2 array2 dcumulator2
 
-    @maybe_turbo turbo for j in indices((cumulator, dcumulator, array2, dcumulator2))
+    @maybe_turbo turbo for j in axes(cumulator, 1)
         x = op(cumulator[j], array2[j])::T
 
         first, second = diff_op(cumulator[j], array2[j])::Tuple{T,T}
@@ -328,12 +328,12 @@ function grad_deg1_eval(
     )
     @return_on_false2 complete cumulator dcumulator
 
-    @maybe_turbo turbo for j in indices((cumulator, dcumulator), (1, 2))
+    @maybe_turbo turbo for j in axes(cumulator, 1)
         x = op(cumulator[j])::T
         dx = diff_op(cumulator[j])::T
 
         cumulator[j] = x
-        for k in indices(dcumulator, 1)
+        for k in axes(dcumulator, 1)
             dcumulator[k, j] = dx * dcumulator[k, j]
         end
     end
@@ -362,15 +362,13 @@ function grad_deg2_eval(
     )
     @return_on_false2 complete2 cumulator1 dcumulator1
 
-    @maybe_turbo turbo for j in indices(
-        (cumulator1, cumulator2, dcumulator1, dcumulator2), (1, 1, 2, 2)
-    )
+    @maybe_turbo turbo for j in axes(cumulator1, 1)
         c1 = cumulator1[j]
         c2 = cumulator2[j]
         x = op(c1, c2)::T
         dx1, dx2 = diff_op(c1, c2)::Tuple{T,T}
         cumulator1[j] = x
-        for k in indices((dcumulator1, dcumulator2), (1, 1))
+        for k in axes(dcumulator1, 1)
             dcumulator1[k, j] = dx1 * dcumulator1[k, j] + dx2 * dcumulator2[k, j]
         end
     end

--- a/src/ExtensionInterface.jl
+++ b/src/ExtensionInterface.jl
@@ -15,4 +15,6 @@ function symbolic_to_node(args...; kws...)
     )
 end
 
+generate_diff_operators(args...) = error("`Zygote` not loaded.")
+
 end

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -224,12 +224,13 @@ function OperatorEnum(;
     diff_unary_operators = Function[]
 
     if enable_autodiff
+        gradient = LazyZygote.gradient
         for op in binary_operators
-            diff_op(x, y) = LazyZygote.gradient(op, x, y)
+            diff_op(x, y) = gradient(op, x, y)
             push!(diff_binary_operators, diff_op)
         end
         for op in unary_operators
-            diff_op(x) = LazyZygote.gradient(op, x)[1]
+            diff_op(x) = gradient(op, x)[1]
             push!(diff_unary_operators, diff_op)
         end
     end

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -5,8 +5,7 @@ import ..EquationModule: string_tree, Node
 import ..EvaluateEquationModule: eval_tree_array
 import ..EvaluateEquationDerivativeModule: eval_grad_tree_array
 import ..EvaluationHelpersModule: _grad_evaluator
-
-generate_diff_operators(args...) = error("`Zygote` not loaded.")
+import ..ExtensionInterfaceModule: generate_diff_operators
 
 function create_evaluation_helpers!(operators::OperatorEnum)
     @eval begin
@@ -221,7 +220,7 @@ function OperatorEnum(;
 
     diff_bin, diff_una = if enable_autodiff
         Base.require(@__MODULE__, :Zygote)
-        generate_diff_operators(binary_operators, unary_operators)
+        Base.invokelatest(generate_diff_operators, binary_operators, unary_operators)
     else
         Function[], Function[]
     end

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -253,14 +253,13 @@ function generate_diff_operators(binary_operators, unary_operators)
     Zygote = load_zygote()
     gradient = Zygote.gradient
     for op in binary_operators
-        diff_op(x, y) = gradient(op, x, y)
+        diff_op(x, y) = Base.invokelatest(gradient, op, x, y)
         push!(diff_bin, diff_op)
     end
     for op in unary_operators
-        diff_op(x) = gradient(op, x)[1]
+        diff_op(x) = Base.invokelatest(gradient, op, x)[1]
         push!(diff_una, diff_op)
     end
-
     return diff_bin, diff_una
 end
 

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -1,22 +1,16 @@
 module OperatorEnumConstructionModule
 
+import Requires: @init, @require
 import ..OperatorEnumModule: AbstractOperatorEnum, OperatorEnum, GenericOperatorEnum
 import ..EquationModule: string_tree, Node
 import ..EvaluateEquationModule: eval_tree_array
 import ..EvaluateEquationDerivativeModule: eval_grad_tree_array
 import ..EvaluationHelpersModule: _grad_evaluator
 
-const ZygoteLoaded = Ref(false)
-const ZygoteLock = Threads.SpinLock()
-function load_zygote()
-    ZygoteLoaded.x && return nothing
-    lock(ZygoteLock) do
-        ZygoteLoaded.x && return nothing
-        @eval import Zygote: gradient
-        ZygoteLoaded.x = true
-        return nothing
-    end
-end
+#! format: off
+generate_diff_operators(::Any, ::Any) = error("`Zygote` not loaded.")
+@init @require Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f" include("zygote_interface.jl")
+#! format: on
 
 function create_evaluation_helpers!(operators::OperatorEnum)
     @eval begin
@@ -230,7 +224,8 @@ function OperatorEnum(;
     unary_operators = Function[op for op in unary_operators]
 
     diff_bin, diff_una = if enable_autodiff
-        generate_diff_operators(binary_operators, unary_operators)
+        Base.require(@__MODULE__, :Zygote)
+        Base.invokelatest(generate_diff_operators, binary_operators, unary_operators)
     else
         Function[], Function[]
     end
@@ -243,21 +238,6 @@ function OperatorEnum(;
     end
 
     return operators
-end
-
-function generate_diff_operators(binary_operators, unary_operators)
-    load_zygote()
-    diff_bin = Function[]
-    diff_una = Function[]
-    for op in binary_operators
-        diff_op(x, y) = gradient(op, x, y)
-        push!(diff_bin, diff_op)
-    end
-    for op in unary_operators
-        diff_op(x) = gradient(op, x)[1]
-        push!(diff_una, diff_op)
-    end
-    return diff_bin, diff_una
 end
 
 """

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -1,11 +1,13 @@
 module OperatorEnumConstructionModule
 
-import Zygote: gradient
 import ..OperatorEnumModule: AbstractOperatorEnum, OperatorEnum, GenericOperatorEnum
 import ..EquationModule: string_tree, Node
 import ..EvaluateEquationModule: eval_tree_array
 import ..EvaluateEquationDerivativeModule: eval_grad_tree_array
 import ..EvaluationHelpersModule: _grad_evaluator
+
+import LazyModules: @lazy
+@lazy import Zygote as LazyZygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 function create_evaluation_helpers!(operators::OperatorEnum)
     @eval begin
@@ -223,11 +225,11 @@ function OperatorEnum(;
 
     if enable_autodiff
         for op in binary_operators
-            diff_op(x, y) = gradient(op, x, y)
+            diff_op(x, y) = LazyZygote.gradient(op, x, y)
             push!(diff_binary_operators, diff_op)
         end
         for op in unary_operators
-            diff_op(x) = gradient(op, x)[1]
+            diff_op(x) = LazyZygote.gradient(op, x)[1]
             push!(diff_unary_operators, diff_op)
         end
     end

--- a/src/zygote_interface.jl
+++ b/src/zygote_interface.jl
@@ -1,0 +1,21 @@
+import Zygote: gradient
+
+make_diff_bin(op) = (x, y) -> gradient(op, x, y)
+make_diff_una(op) = x -> gradient(op, x)[1]
+
+function generate_diff_operators(
+    binary_operators::Vector{Function}, unary_operators::Vector{Function}
+)
+    diff_bin = Function[]
+    diff_una = Function[]
+
+    for op in binary_operators
+        diff_op = make_diff_bin(op)
+        push!(diff_bin, diff_op)
+    end
+    for op in unary_operators
+        diff_op = make_diff_una(op)
+        push!(diff_una, diff_op)
+    end
+    return diff_bin, diff_una
+end


### PR DESCRIPTION
This will only load Zygote.jl when autodiff is enabled.

The big remaining TTL contributor is LoopVectorization.jl (direct) and VectorizationBase.jl (indirect), which are also optional. However, since LoopVectorization.jl is used for a macro, I'm not sure whether it can be loaded lazily?