### PR TITLE
Allow user-defined printing

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -102,11 +102,11 @@ function benchmark_utilities()
     )
 
     operators = OperatorEnum(; binary_operators=[+, -, /, *], unary_operators=[cos, exp])
-
     for func_k in all_funcs
         suite[func_k] = let s = BenchmarkGroup()
             for k in (:break_sharing, :preserve_sharing)
-                k == :preserve_sharing && !(func_k in (:copy, :convert)) && continue
+                has_both_modes = func_k in (:copy, :convert)
+                k == :preserve_sharing && !has_both_modes && continue
 
                 f = if func_k == :copy
                     tree -> _copy_node(tree; preserve_sharing=(k == :preserve_sharing))
@@ -134,6 +134,9 @@ function benchmark_utilities()
                         trees=[gen_random_tree_fixed_size(n, $operators, 5, Float32) for _ in 1:ntrees]
                     )
                 )
+                if !has_both_modes
+                    s = s[k]
+                end
                 #! format: on
             end
             s

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -98,6 +98,7 @@ function benchmark_utilities()
         :is_constant,
         :get_set_constants!,
         :index_constants,
+        :string_tree,
     )
 
     operators = OperatorEnum(; binary_operators=[+, -, /, *], unary_operators=[cos, exp])
@@ -115,7 +116,7 @@ function benchmark_utilities()
                         tree;
                         preserve_sharing=(k == :preserve_sharing),
                     )
-                elseif func_k in (:simplify_tree, :combine_operators)
+                elseif func_k in (:simplify_tree, :combine_operators, :string_tree)
                     g = getfield(@__MODULE__, func_k)
                     tree -> f_tree_op(g, tree, operators)
                 else

--- a/src/Equation.jl
+++ b/src/Equation.jl
@@ -208,27 +208,28 @@ end
 function string_op(
     ::Val{2}, op::F, tree::Node, args...; bracketed, kws...
 )::String where {F}
-    op_name = get_op_name(string(op))
+    op_name = get_op_name(op)
     if op_name in ["+", "-", "*", "/", "^"]
         l = string_tree(tree.l, args...; bracketed=false, kws...)
         r = string_tree(tree.r, args...; bracketed=false, kws...)
         if bracketed
-            return "$l $op_name $r"
+            return l * " " * op_name * " " * r
         else
-            return "($l $op_name $r)"
+            return "(" * l * " " * op_name * " " * r * ")"
         end
     else
         l = string_tree(tree.l, args...; bracketed=true, kws...)
         r = string_tree(tree.r, args...; bracketed=true, kws...)
-        return "$op_name($l, $r)"
+        # return "$op_name($l, $r)"
+        return op_name * "(" * l * ", " * r * ")"
     end
 end
 function string_op(
     ::Val{1}, op::F, tree::Node, args...; bracketed, kws...
 )::String where {F}
-    op_name = get_op_name(string(op))
+    op_name = get_op_name(op)
     l = string_tree(tree.l, args...; bracketed=true, kws...)
-    return "$(op_name)($l)"
+    return op_name * "(" * l * ")"
 end
 
 function string_constant(val, bracketed::Bool)
@@ -242,7 +243,7 @@ end
 
 function string_variable(feature, variable_names)
     if variable_names === nothing
-        return "x$(feature)"
+        return "x" * string(feature)
     else
         return @inbounds(variable_names[feature])
     end

--- a/src/Equation.jl
+++ b/src/Equation.jl
@@ -245,7 +245,7 @@ function string_variable(feature, variable_names)
     if variable_names === nothing
         return "x" * string(feature)
     else
-        return @inbounds(variable_names[feature])
+        return variable_names[feature]
     end
 end
 

--- a/src/Equation.jl
+++ b/src/Equation.jl
@@ -190,8 +190,19 @@ const OP_NAMES = Dict(
     "safe_pow" => "^",
 )
 
-function get_op_name(op::String)
-    return get(OP_NAMES, op, op)
+@generated function get_op_name(op::F) where {F}
+    try
+        # Bit faster to just cache the name of the operator:
+        op_s = string(F.instance)
+        out = get(OP_NAMES, op_s, op_s)
+        return :($out)
+    catch
+    end
+    return quote
+        op_s = string(op)
+        out = get(OP_NAMES, op_s, op_s)
+        return out
+    end
 end
 
 function string_op(

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -39,6 +39,20 @@ for binop in [safe_pow, ^]
     @test string_tree(minitree, opts) == "(x1 ^ x2)"
 end
 
+@testset "Test print_tree function" begin
+    operators = OperatorEnum(; binary_operators=(+, *, /, -), unary_operators=(cos, sin))
+    x1, x2, x3 = [Node(Float64; feature=i) for i in 1:3]
+    tree = x1 * x1 + 0.5
+    # Capture stdout to variable:
+    pipe = Pipe()
+    redirect_stdout(pipe) do
+        print_tree(tree, operators)
+    end
+    close(pipe.in)
+    s = read(pipe.out, String)
+    @test s == "((x1 * x1) + 0.5)\n"
+end
+
 @testset "Test printing of complex numbers" begin
     @eval my_custom_op(x, y) = x + y
     operators = OperatorEnum(;

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -67,7 +67,7 @@ end
     @test string_tree(tree, operators; f_variable=Returns("TEST")) ==
         "((TEST * TEST) + 0.5)"
     @test string_tree(
-        tree, operators; f_variable=Returns("TEST"), f_variable=Returns("TEST2")
+        tree, operators; f_variable=Returns("TEST"), f_constant=Returns("TEST2")
     ) == "((TEST * TEST) + TEST2)"
 
     # Try printing with a precision:

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -41,17 +41,21 @@ for binop in [safe_pow, ^]
 end
 
 @testset "Test print_tree function" begin
-    operators = OperatorEnum(; binary_operators=(+, *, /, -), unary_operators=(cos, sin))
-    x1, x2, x3 = [Node(Float64; feature=i) for i in 1:3]
-    tree = x1 * x1 + 0.5
-    # Capture stdout to variable:
-    pipe = Pipe()
-    redirect_stdout(pipe) do
-        print_tree(tree, operators)
+    if VERSION > v"1.8"
+        operators = OperatorEnum(;
+            binary_operators=(+, *, /, -), unary_operators=(cos, sin)
+        )
+        x1, x2, x3 = [Node(Float64; feature=i) for i in 1:3]
+        tree = x1 * x1 + 0.5
+        # Capture stdout to variable:
+        pipe = Pipe()
+        redirect_stdout(pipe) do
+            print_tree(tree, operators)
+        end
+        close(pipe.in)
+        s = read(pipe.out, String)
+        @test s == "((x1 * x1) + 0.5)\n"
     end
-    close(pipe.in)
-    s = read(pipe.out, String)
-    @test s == "((x1 * x1) + 0.5)\n"
 end
 
 @testset "Test printing of complex numbers" begin

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -1,5 +1,6 @@
 using Test
 using DynamicExpressions
+import Compat: Returns
 
 include("test_params.jl")
 


### PR DESCRIPTION
This creates keyword arguments for `string_tree` (and `print_tree`) which can take a custom function for printing variables and constants in a tree. e.g., 

```julia
    operators = OperatorEnum(;
        binary_operators=(+, *, /, -), unary_operators=(cos, sin)
    )
    x1, x2, x3 = [Node(Float64; feature=i) for i in 1:3]
    tree = x1 * x1 + π
    f_constant(val::Float64, args...) = string(round(val; digits=4))
    @test string_tree(tree, operators; f_constant=f_constant) == "((x1 * x1) + 3.1416)"
```