### PR TITLE
Avoid method invalidation in helper functions

### DIFF
--- a/src/Equation.jl
+++ b/src/Equation.jl
@@ -190,6 +190,7 @@ const OP_NAMES = Dict(
     "safe_pow" => "^",
 )
 
+get_op_name(op::String) = op
 @generated function get_op_name(op::F) where {F}
     try
         # Bit faster to just cache the name of the operator:
@@ -266,7 +267,7 @@ Convert an equation to a string.
 """
 function string_tree(
     tree::Node{T},
-    operators::AbstractOperatorEnum;
+    operators::Union{AbstractOperatorEnum,Nothing}=nothing;
     bracketed::Bool=false,
     f_variable::F1=string_variable,
     f_constant::F2=string_constant,
@@ -284,7 +285,11 @@ function string_tree(
     elseif tree.degree == 1
         return string_op(
             Val(1),
-            operators.unaops[tree.op],
+            if operators === nothing
+                "unary_operator[" * string(tree.op) * "]"
+            else
+                operators.unaops[tree.op]
+            end,
             tree,
             operators;
             bracketed,
@@ -295,7 +300,11 @@ function string_tree(
     else
         return string_op(
             Val(2),
-            operators.binops[tree.op],
+            if operators === nothing
+                "binary_operator[" * string(tree.op) * "]"
+            else
+                operators.binops[tree.op]
+            end,
             tree,
             operators;
             bracketed,

--- a/src/EvaluationHelpers.jl
+++ b/src/EvaluationHelpers.jl
@@ -54,13 +54,6 @@ function (tree::Node)(X, operators::GenericOperatorEnum; kws...)
     !did_finish && return nothing
     return out
 end
-function (tree::Node)(X; kws...)
-    ## This will be overwritten by OperatorEnumConstructionModule, and turned
-    ## into a depwarn.
-    return error(
-        "The `tree(X; kws...)` syntax is deprecated. Use `tree(X, operators; kws...)` instead.",
-    )
-end
 
 # Gradients:
 function _grad_evaluator(tree::Node, X, operators::OperatorEnum; variable=true, kws...)
@@ -72,13 +65,6 @@ function _grad_evaluator(tree::Node, X, operators::OperatorEnum; variable=true, 
 end
 function _grad_evaluator(tree::Node, X, operators::GenericOperatorEnum; kws...)
     return error("Gradients are not implemented for `GenericOperatorEnum`.")
-end
-function _grad_evaluator(tree::Node, X; kws...)
-    ## This will be overwritten by OperatorEnumConstructionModule, and turned
-    ## into a depwarn
-    return error(
-        "The `tree'(X; kws...)` syntax is deprecated. Use `tree'(X, operators; kws...)` instead.",
-    )
 end
 
 """

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -31,7 +31,7 @@ const ALREADY_DEFINED_BINARY_OPERATORS = (;
 function Base.show(io::IO, tree::Node)
     latest_operators_type = LATEST_OPERATORS_TYPE.x
     if latest_operators_type == IsNothing
-        return print(io, string(tree))
+        return print(io, string_tree(tree))
     elseif latest_operators_type == IsOperatorEnum
         latest_operators = LATEST_OPERATORS.x::OperatorEnum
         return print(io, string_tree(tree, latest_operators))

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -4,11 +4,11 @@ using DynamicExpressions: eval_diff_tree_array, eval_grad_tree_array
 using Random
 using Zygote
 using LinearAlgebra
+include("test_params.jl")
 
 seed = 0
 # SIMD doesn't like abs(x) ^ y for some reason.
 pow_abs2(x, y) = exp(y * log(abs(x)))
-custom_cos(x) = cos(x)^2
 
 equation1(x1, x2, x3) = x1 + x2 + x3 + 3.2
 equation2(x1, x2, x3) = pow_abs2(x1, x2) + x3 + custom_cos(1.0 + x3) + 3.0 / x1

--- a/test/test_initial_errors.jl
+++ b/test/test_initial_errors.jl
@@ -1,0 +1,35 @@
+using DynamicExpressions
+using Test
+using Zygote
+
+# Before defining OperatorEnum, calling the implicit (deprecated)
+# syntax should fail:
+tree = Node(; feature=1)
+@test_throws ErrorException tree([1.0 2.0]')
+@test_throws "Please use the " tree([1.0 2.0]')
+@test_throws ErrorException tree'([1.0 2.0]')
+@test_throws "Please use the " tree'([1.0 2.0]')
+
+@test string(tree) == "x1"
+@test string(Node(1, tree)) == "unary_operator[1](x1)"
+@test string(Node(1, tree, tree)) == "binary_operator[1](x1, x1)"
+
+# Also test warnings:
+for constructor in (OperatorEnum, GenericOperatorEnum)
+    operators = constructor(;
+        binary_operators=[+, -, *, /],
+        unary_operators=[cos, sin],
+        (constructor == OperatorEnum ? (enable_autodiff=true,) : ())...,
+    )
+    tree([1.0 2.0]')
+    # Can't test for this:
+    # expected_warn_msg = "The `tree(X; kws...)` syntax is deprecated"
+    # @test occursin(expected_warn_msg, msg)
+
+    constructor == GenericOperatorEnum && continue
+
+    tree'([1.0 2.0]')
+    # Can't test for this:
+    # expected_warn_msg = "The `tree'(X; kws...)` syntax is deprecated"
+    # @test occursin(expected_warn_msg, msg)
+end

--- a/test/test_initial_errors.jl
+++ b/test/test_initial_errors.jl
@@ -5,10 +5,13 @@ using Zygote
 # Before defining OperatorEnum, calling the implicit (deprecated)
 # syntax should fail:
 tree = Node(; feature=1)
-@test_throws ErrorException tree([1.0 2.0]')
-@test_throws "Please use the " tree([1.0 2.0]')
-@test_throws ErrorException tree'([1.0 2.0]')
-@test_throws "Please use the " tree'([1.0 2.0]')
+
+if VERSION >= v"1.8"
+    @test_throws ErrorException tree([1.0 2.0]')
+    @test_throws "Please use the " tree([1.0 2.0]')
+    @test_throws ErrorException tree'([1.0 2.0]')
+    @test_throws "Please use the " tree'([1.0 2.0]')
+end
 
 @test string(tree) == "x1"
 @test string(Node(1, tree)) == "unary_operator[1](x1)"

--- a/test/test_params.jl
+++ b/test/test_params.jl
@@ -1,30 +1,35 @@
 using DynamicExpressions
 
 maximum_residual = 1e-2
-safe_log(x::T) where {T} = (x <= 0) ? T(NaN) : log(x)
-safe_log2(x::T) where {T} = (x <= 0) ? T(NaN) : log2(x)
-safe_log10(x::T) where {T} = (x <= 0) ? T(NaN) : log10(x)
-safe_log1p(x::T) where {T} = (x <= -1) ? T(NaN) : log1p(x)
-safe_sqrt(x::T) where {T} = (x < 0) ? T(NaN) : sqrt(x)
-safe_pow(x::T, y::T) where {T} = (x < 0 && y != round(y)) ? T(NaN) : x^y
-relu(x::T) where {T} = (x < 0) ? zero(T) : x
-safe_acosh(x::T) where {T} = (x < 1) ? T(NaN) : acosh(x)
-sub(x::T, y::T) where {T} = x - y
-greater(x::T, y::T) where {T} = (x > y) ? one(T) : zero(T)
 
-safe_log(x) = log(x)
-safe_log2(x) = log2(x)
-safe_log10(x) = log10(x)
-safe_log1p(x) = log1p(x)
-safe_sqrt(x) = sqrt(x)
-safe_pow(x, y) = x^y
-relu(x) = max(x, 0)
-safe_acosh(x) = acosh(x)
-sub(x, y) = x - y
-square(x) = x * x
-cube(x) = x * x * x
-greater(x, y) = (x > y)
+(@isdefined HEADER_GUARD_TEST_PARAMS) || @eval begin
+    safe_log(x::T) where {T<:Number} = (x <= 0) ? T(NaN) : log(x)
+    safe_log2(x::T) where {T<:Number} = (x <= 0) ? T(NaN) : log2(x)
+    safe_log10(x::T) where {T<:Number} = (x <= 0) ? T(NaN) : log10(x)
+    safe_log1p(x::T) where {T<:Number} = (x <= -1) ? T(NaN) : log1p(x)
+    safe_sqrt(x::T) where {T<:Number} = (x < 0) ? T(NaN) : sqrt(x)
+    safe_pow(x::T, y::T) where {T<:Number} = (x < 0 && y != round(y)) ? T(NaN) : x^y
+    relu(x::T) where {T<:Number} = (x < 0) ? zero(T) : x
+    safe_acosh(x::T) where {T<:Number} = (x < 1) ? T(NaN) : acosh(x)
+    sub(x::T, y::T) where {T<:Number} = x - y
+    greater(x::T, y::T) where {T<:Number} = (x > y) ? one(T) : zero(T)
 
-custom_cos(x) = cos(x)
+    safe_log(x) = log(x)
+    safe_log2(x) = log2(x)
+    safe_log10(x) = log10(x)
+    safe_log1p(x) = log1p(x)
+    safe_sqrt(x) = sqrt(x)
+    safe_pow(x, y) = x^y
+    relu(x) = max(x, 0)
+    safe_acosh(x) = acosh(x)
+    sub(x, y) = x - y
+    square(x) = x * x
+    cube(x) = x * x * x
+    greater(x, y) = (x > y)
+
+    custom_cos(x) = cos(x)
+end
+
+HEADER_GUARD_TEST_PARAMS = true
 
 default_params = (binary_operators=(/, +, *), unary_operators=(exp, custom_cos))

--- a/test/test_params.jl
+++ b/test/test_params.jl
@@ -8,7 +8,6 @@ maximum_residual = 1e-2
     safe_log10(x::T) where {T<:Number} = (x <= 0) ? T(NaN) : log10(x)
     safe_log1p(x::T) where {T<:Number} = (x <= -1) ? T(NaN) : log1p(x)
     safe_sqrt(x::T) where {T<:Number} = (x < 0) ? T(NaN) : sqrt(x)
-    safe_pow(x::T, y::T) where {T<:Number} = (x < 0 && y != round(y)) ? T(NaN) : x^y
     relu(x::T) where {T<:Number} = (x < 0) ? zero(T) : x
     safe_acosh(x::T) where {T<:Number} = (x < 1) ? T(NaN) : acosh(x)
     sub(x::T, y::T) where {T<:Number} = x - y
@@ -19,7 +18,6 @@ maximum_residual = 1e-2
     safe_log10(x) = log10(x)
     safe_log1p(x) = log1p(x)
     safe_sqrt(x) = sqrt(x)
-    safe_pow(x, y) = x^y
     relu(x) = max(x, 0)
     safe_acosh(x) = acosh(x)
     sub(x, y) = x - y
@@ -27,7 +25,7 @@ maximum_residual = 1e-2
     cube(x) = x * x * x
     greater(x, y) = (x > y)
 
-    custom_cos(x) = cos(x)
+    custom_cos(x) = cos(x)^2
 end
 
 HEADER_GUARD_TEST_PARAMS = true

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -32,6 +32,8 @@ for unaop in [safe_log, safe_log2, safe_log10, safe_log1p, safe_sqrt, safe_acosh
     @test string_tree(minitree, opts) == replace(string(unaop), "safe_" => "") * "(x1)"
 end
 
+!(@isdefined safe_pow) &&
+    @eval safe_pow(x::T, y::T) where {T<:Number} = (x < 0 && y != round(y)) ? T(NaN) : x^y
 for binop in [safe_pow, ^]
     opts = OperatorEnum(;
         default_params..., binary_operators=(+, *, /, -, binop), unary_operators=(cos,)

--- a/test/test_safe_helpers.jl
+++ b/test/test_safe_helpers.jl
@@ -1,0 +1,31 @@
+using DynamicExpressions
+using Test
+
+function _square(x)
+    return x^2
+end
+
+operators = OperatorEnum(;
+    binary_operators=[+, -, *, /], unary_operators=[cos, sin, _square]
+)
+@extend_operators operators
+x1, x2, x3 = (i -> Node(Float64; feature=i)).(1:3)
+
+# Should work normally:
+@test _square(x1 + x2 / x3) * x2 + 0.5 isa Node
+
+# But, upon redefining `operators`, we should get errors:
+operators = OperatorEnum(; binary_operators=[+, -, *], unary_operators=[cos, sin, _square])
+
+# Safe:
+@test _square(x1 + x2) * x2 + 0.5 isa Node
+
+# Breaks:
+@test_throws ErrorException _square(x1 + x2 / x3) * x2 + 0.5
+
+operators = OperatorEnum(; binary_operators=[+, -, *, /], unary_operators=[cos, sin])
+# Safe:
+@test (x1 + x2 / x3) * x2 + 0.5 isa Node
+
+# Breaks:
+@test_throws ErrorException _square(x1 + x2 / x3) * x2 + 0.5

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -49,19 +49,11 @@ tree_copy = convert(Node, eqn, operators)
 # with custom operators, and unary operators:
 x1, x2, x3 = Node("x1"), Node("x2"), Node("x3")
 pow_abs2(x, y) = abs(x)^y
-custom_cos(x) = cos(x)^2
-
-# Define for Node (usually these are done internally to OperatorEnum)
-pow_abs2(l::Node, r::Node)::Node =
-    (l.constant && r.constant) ? Node(pow_abs2(l.val, r.val)::Real) : Node(5, l, r)
-pow_abs2(l::Node, r::Real)::Node =
-    l.constant ? Node(pow_abs2(l.val, r)::Real) : Node(5, l, r)
-pow_abs2(l::Real, r::Node)::Node =
-    r.constant ? Node(pow_abs2(l, r.val)::Real) : Node(5, l, r)
-custom_cos(x::Node)::Node = x.constant ? Node(custom_cos(x.val)::Real) : Node(1, x)
 
 operators = OperatorEnum(;
-    binary_operators=(+, *, -, /, pow_abs2), unary_operators=(custom_cos, exp, sin)
+    binary_operators=(+, *, -, /, pow_abs2),
+    unary_operators=(custom_cos, exp, sin),
+    define_helper_functions,
 )
 tree = (
     ((x2 + x2) * ((-0.5982493 / pow_abs2(x1, x2)) / -0.54734415)) + (

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -51,10 +51,9 @@ x1, x2, x3 = Node("x1"), Node("x2"), Node("x3")
 pow_abs2(x, y) = abs(x)^y
 
 operators = OperatorEnum(;
-    binary_operators=(+, *, -, /, pow_abs2),
-    unary_operators=(custom_cos, exp, sin),
-    define_helper_functions,
+    binary_operators=(+, *, -, /, pow_abs2), unary_operators=(custom_cos, exp, sin)
 )
+@extend_operators operators
 tree = (
     ((x2 + x2) * ((-0.5982493 / pow_abs2(x1, x2)) / -0.54734415)) + (
         sin(

--- a/test/test_symbolic_utils.jl
+++ b/test/test_symbolic_utils.jl
@@ -4,14 +4,24 @@ using Test
 include("test_params.jl")
 
 _inv(x) = 1 / x
-safe_pow(x::T, y::T) where {T} = (x < 0 && y != round(y)) ? T(NaN) : x^y
-greater(x::T, y::T) where {T} = (x > y) ? one(T) : zero(T)
+!(@isdefined safe_pow) &&
+    @eval safe_pow(x::T, y::T) where {T<:Number} = (x < 0 && y != round(y)) ? T(NaN) : x^y
+!(@isdefined greater) && @eval greater(x::T, y::T) where {T} = (x > y) ? one(T) : zero(T)
+
+tree =
+    let tmp_op = OperatorEnum(;
+            default_params...,
+            binary_operators=(+, *, ^, /, greater),
+            unary_operators=(_inv,),
+        )
+        Node(5, (Node(; val=3.0) * Node(1, Node("x1")))^2.0, Node(; val=-1.2))
+    end
+
 operators = OperatorEnum(;
     default_params...,
     binary_operators=(+, *, safe_pow, /, greater),
     unary_operators=(_inv,),
 )
-tree = Node(5, (Node(; val=3.0) * Node(1, Node("x1")))^2.0, Node(; val=-1.2))
 
 eqn = node_to_symbolic(tree, operators; variable_names=["energy"], index_functions=true)
 @test string(eqn) == "greater(safe_pow(3.0_inv(energy), 2.0), -1.2)"

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -16,13 +16,13 @@ x1, x2, x3 = Node("x1"), Node("x2"), Node("x3")
 # Has constants:
 @test has_constants(x1) == false
 @test has_constants(x1 + 1) == true
-@test has_constants(cos(x1)) == false
-@test has_constants(cos(Node(; val=0.0))) == true
+@test has_constants(sin(x1)) == false
+@test has_constants(sin(Node(; val=0.0))) == true
 
 # Has operators
 @test has_operators(x1) == false
 @test has_operators(x1 + 1) == true
-@test has_operators(cos(x1)) == true
+@test has_operators(sin(x1)) == true
 @test has_operators(Node(; val=0.0)) == false
 
 # Set constants:

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -101,3 +101,7 @@ end
 @safetestset "Test containers preserved" begin
     include("test_container_preserved.jl")
 end
+
+@safetestset "Test helpers break upon redefining" begin
+    include("test_safe_helpers.jl")
+end

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -1,29 +1,7 @@
 using SafeTestsets
 
 @safetestset "Initial error handling test" begin
-    using DynamicExpressions
-    using Test
-
-    # Before defining OperatorEnum, calling the implicit (deprecated)
-    # syntax should fail:
-    tree = Node(; feature=1)
-    try
-        tree([1.0 2.0]')
-        @test false
-    catch e
-        @test isa(e, ErrorException)
-        expected_error_msg = "The `tree(X; kws...)` syntax is deprecated"
-        @test occursin(expected_error_msg, e.msg)
-    end
-
-    try
-        tree'([1.0 2.0]')
-        @test false
-    catch e
-        @test isa(e, ErrorException)
-        expected_error_msg = "The `tree'(X; kws...)` syntax is deprecated"
-        @test occursin(expected_error_msg, e.msg)
-    end
+    include("test_initial_errors.jl")
 end
 
 @safetestset "Test tree construction and scoring" begin


### PR DESCRIPTION
Needed for v1.10 to avoid the list of method invalidation warnings.

This also increases safety of the helper functions (e.g., using `*` on two `Node` types), by checking whether the operator was redefined or not.