### PR TITLE
Allow operator aliases

### DIFF
--- a/src/DynamicExpressions.jl
+++ b/src/DynamicExpressions.jl
@@ -27,7 +27,7 @@ import Reexport: @reexport
     set_constants!
 @reexport import .OperatorEnumModule: AbstractOperatorEnum
 @reexport import .OperatorEnumConstructionModule:
-    OperatorEnum, GenericOperatorEnum, @extend_operators
+    OperatorEnum, GenericOperatorEnum, @extend_operators, set_default_variable_names!
 @reexport import .EvaluateEquationModule: eval_tree_array, differentiable_eval_tree_array
 @reexport import .EvaluateEquationDerivativeModule:
     eval_diff_tree_array, eval_grad_tree_array

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -79,15 +79,19 @@ function _grad_evaluator(tree::Node, X; kws...)
     end
 end
 
+function set_default_variable_names!(variable_names::Vector{String})
+    return LATEST_VARIABLE_NAMES.x = variable_names
+end
+
 function create_evaluation_helpers!(operators::OperatorEnum)
     LATEST_OPERATORS.x = operators
     return LATEST_OPERATORS_TYPE.x = IsOperatorEnum
 end
-
 function create_evaluation_helpers!(operators::GenericOperatorEnum)
     LATEST_OPERATORS.x = operators
     return LATEST_OPERATORS_TYPE.x = IsGenericOperatorEnum
 end
+
 function lookup_op(@nospecialize(f), ::Val{degree}) where {degree}
     mapping = degree == 1 ? LATEST_UNARY_OPERATOR_MAPPING : LATEST_BINARY_OPERATOR_MAPPING
     if !haskey(mapping, f)

--- a/src/OperatorEnumConstruction.jl
+++ b/src/OperatorEnumConstruction.jl
@@ -185,7 +185,7 @@ function _extend_operators(operators, skip_user_operators, __module__::Module)
         local build_converters
         local binary_exists
         local unary_exists
-        if isa($operators, OperatorEnum)
+        if isa($operators, $OperatorEnum)
             type_requirements = Number
             build_converters = true
             binary_exists = $(ALREADY_DEFINED_BINARY_OPERATORS).operator_enum

--- a/test/test_print.jl
+++ b/test/test_print.jl
@@ -111,7 +111,7 @@ end
     empty!(DynamicExpressions.OperatorEnumConstructionModule.LATEST_VARIABLE_NAMES.x)
     @test string(tree) == "((x1 * x2) + x3)"
     # Check if we can pass the wrong number of variable names:
-    DynamicExpressions.OperatorEnumConstructionModule.LATEST_VARIABLE_NAMES.x = ["k1"]
+    set_default_variable_names!(["k1"])
     @test string(tree) == "((k1 * x2) + x3)"
     empty!(DynamicExpressions.OperatorEnumConstructionModule.LATEST_VARIABLE_NAMES.x)
 end

--- a/test/test_safe_helpers.jl
+++ b/test/test_safe_helpers.jl
@@ -29,3 +29,10 @@ operators = OperatorEnum(; binary_operators=[+, -, *, /], unary_operators=[cos, 
 
 # Breaks:
 @test_throws ErrorException _square(x1 + x2 / x3) * x2 + 0.5
+
+# We can also turn this behavior off:
+operators = OperatorEnum(; binary_operators=[+, -, *, /], unary_operators=[cos, sin])
+operators = OperatorEnum(;
+    binary_operators=[+, -, *, /], unary_operators=[cos, tan], empty_old_operators=false
+)
+@test tan(x1) == sin(x1)

--- a/test/test_safe_helpers.jl
+++ b/test/test_safe_helpers.jl
@@ -36,3 +36,8 @@ operators = OperatorEnum(;
     binary_operators=[+, -, *, /], unary_operators=[cos, tan], empty_old_operators=false
 )
 @test tan(x1) == sin(x1)
+
+# Should catch errors in kws:
+@test_throws LoadError begin
+    @eval @extend_operators operators empty_old_operators_bad_kw = true
+end


### PR DESCRIPTION
This creates the `empty_old_operators` keyword to `@extend_operators` which effectively lets you prevent the call to `empty!(LATEST_BINARY_OPERATOR_MAPPING)`, which means you can have multiple operators producing the same index. This is good for aliases like `safe_pow` and `^` meaning the same thing.