### PR TITLE
Type stable wrapping of Zygote gradients

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicExpressions"
 uuid = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.12.2"
+version = "0.12.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/ext/DynamicExpressionsZygoteExt.jl
+++ b/ext/DynamicExpressionsZygoteExt.jl
@@ -3,7 +3,17 @@ module DynamicExpressionsZygoteExt
 import Zygote: gradient
 import DynamicExpressions.EvaluateEquationDerivativeModule: _zygote_gradient
 
-_zygote_gradient(op::F, ::Val{1}) where {F} = x -> gradient(op, x)[1]
-_zygote_gradient(op::F, ::Val{2}) where {F} = (x, y) -> gradient(op, x, y)
+function _zygote_gradient(op::F, ::Val{1}) where {F}
+    function (x)
+        out = gradient(op, x)[1]
+        return out === nothing ? zero(x) : out
+    end
+end
+function _zygote_gradient(op::F, ::Val{2}) where {F}
+    function (x, y)
+        (∂x, ∂y) = gradient(op, x, y)
+        return (∂x === nothing ? zero(x) : ∂x, ∂y === nothing ? zero(y) : ∂y)
+    end
+end
 
 end

--- a/test/test_undefined_derivatives.jl
+++ b/test/test_undefined_derivatives.jl
@@ -19,5 +19,3 @@ x = zeros(3, 1) .- 1
 # Normally, Zygote's gradients would return `nothing`.
 # However, we wrap the gradient to keep it type-stable.
 @test all(isnan, tree'(x, operators; variable=true))
-
-@test x1'(x, operators; variable=true) == [1.0; 0.0; 0.0;;]

--- a/test/test_undefined_derivatives.jl
+++ b/test/test_undefined_derivatives.jl
@@ -1,0 +1,23 @@
+using Test, DynamicExpressions, Zygote
+
+safe_log(x) = x > 0 ? log(x) : convert(eltype(x), NaN)
+
+operators = OperatorEnum(;
+    binary_operators=[+, *, -, /], unary_operators=[safe_log, cos], enable_autodiff=true
+)
+
+@extend_operators operators
+
+x1, x2, x3 = (i -> Node(Float64; feature=i)).(1:3)
+
+tree = safe_log(x1)
+
+x = zeros(3, 1) .- 1
+
+@test all(isnan, tree(x, operators))
+
+# Normally, Zygote's gradients would return `nothing`.
+# However, we wrap the gradient to keep it type-stable.
+@test all(isnan, tree'(x, operators; variable=true))
+
+@test x1'(x, operators; variable=true) == [1.0; 0.0; 0.0;;]

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -20,6 +20,10 @@ end
     include("test_derivatives.jl")
 end
 
+@safetestset "Test undefined derivatives" begin
+    include("test_undefined_derivatives.jl")
+end
+
 @safetestset "Test simplification" begin
     include("test_simplification.jl")
 end


### PR DESCRIPTION
Zygote gradients return `nothing` when a variable is not used. For example, in a branch of an operator which does not use a variable.

This PR implements a fix for this behavior to ensure type stability.