### PR TITLE
Create `AbstractNode` super type

### DIFF
--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -83,3 +83,9 @@ You can create a copy of a node with `copy_node`:
 ```@docs
 copy_node(tree::Node)
 ```
+
+There is also an abstract type `AbstractNode` which is a supertype of `Node`:
+
+```@docs
+AbstractNode
+```

--- a/src/DynamicExpressions.jl
+++ b/src/DynamicExpressions.jl
@@ -14,7 +14,14 @@ include("ExtensionInterface.jl")
 import PackageExtensionCompat: @require_extensions
 import Reexport: @reexport
 @reexport import .EquationModule:
-    Node, string_tree, print_tree, copy_node, set_node!, tree_mapreduce, filter_map
+    AbstractNode,
+    Node,
+    string_tree,
+    print_tree,
+    copy_node,
+    set_node!,
+    tree_mapreduce,
+    filter_map
 @reexport import .EquationUtilsModule:
     count_nodes,
     count_constants,

--- a/src/Equation.jl
+++ b/src/Equation.jl
@@ -13,8 +13,13 @@ Abstract type for binary trees. Must have the following fields:
 - `degree::Integer`: Degree of the node. Either 0, 1, or 2. If 1,
     then `l` needs to be defined as the left child. If 2,
     then `r` also needs to be defined as the right child.
-- `l::AbstractNode`: Left child of the current node.
-- `r::AbstractNode`: Right child of the current node.
+- `l::AbstractNode`: Left child of the current node. Should only be
+    defined if `degree >= 1`; otherwise, leave it undefined (see the
+    the constructors of `Node{T}` for an example).
+    Don't use `nothing` to represent an undefined value
+    as it will incur a large performance penalty.
+- `r::AbstractNode`: Right child of the current node. Should only
+    be defined if `degree == 2`.
 """
 abstract type AbstractNode end
 

--- a/src/Equation.jl
+++ b/src/Equation.jl
@@ -5,6 +5,19 @@ import ..UtilsModule: @memoize_on, @with_memoize, deprecate_varmap
 
 const DEFAULT_NODE_TYPE = Float32
 
+"""
+    AbstractNode
+
+Abstract type for binary trees. Must have the following fields:
+
+- `degree::Integer`: Degree of the node. Either 0, 1, or 2. If 1,
+    then `l` needs to be defined as the left child. If 2,
+    then `r` also needs to be defined as the right child.
+- `l::AbstractNode`: Left child of the current node.
+- `r::AbstractNode`: Right child of the current node.
+"""
+abstract type AbstractNode end
+
 #! format: off
 """
     Node{T}
@@ -36,7 +49,7 @@ nodes, you can evaluate or print a given expression.
     Same type as the parent node. This is to be passed as the right
     argument to the binary operator.
 """
-mutable struct Node{T}
+mutable struct Node{T} <: AbstractNode
     degree::UInt8  # 0 for constant/variable, 1 for cos/sin, 2 for +/* etc.
     constant::Bool  # false if variable
     val::Union{T,Nothing}  # If is a constant, this stores the actual value

--- a/src/EquationUtils.jl
+++ b/src/EquationUtils.jl
@@ -1,22 +1,22 @@
 module EquationUtilsModule
 
 import Compat: Returns
-import ..EquationModule: Node, copy_node, tree_mapreduce, any, filter_map
+import ..EquationModule: AbstractNode, Node, copy_node, tree_mapreduce, any, filter_map
 
 """
-    count_nodes(tree::Node{T})::Int where {T}
+    count_nodes(tree::AbstractNode)::Int
 
 Count the number of nodes in the tree.
 """
-count_nodes(tree::Node) = tree_mapreduce(_ -> 1, +, tree)
+count_nodes(tree::AbstractNode) = tree_mapreduce(_ -> 1, +, tree)
 # This code is given as an example. Normally we could just use sum(Returns(1), tree).
 
 """
-    count_depth(tree::Node{T})::Int where {T}
+    count_depth(tree::AbstractNode)::Int
 
 Compute the max depth of the tree.
 """
-function count_depth(tree::Node)
+function count_depth(tree::AbstractNode)
     return tree_mapreduce(Returns(1), (p, child...) -> p + max(child...), tree)
 end
 

--- a/test/test_custom_node_type.jl
+++ b/test/test_custom_node_type.jl
@@ -1,0 +1,37 @@
+using DynamicExpressions
+using Test
+
+mutable struct MyCustomNode{A,B} <: AbstractNode
+    degree::Int
+    val1::A
+    val2::B
+    l::MyCustomNode{A,B}
+    r::MyCustomNode{A,B}
+
+    MyCustomNode(val1, val2) = new{typeof(val1),typeof(val2)}(0, val1, val2)
+    MyCustomNode(val1, val2, l) = new{typeof(val1),typeof(val2)}(1, val1, val2, l)
+    MyCustomNode(val1, val2, l, r) = new{typeof(val1),typeof(val2)}(2, val1, val2, l, r)
+end
+
+node1 = MyCustomNode(1.0, 2)
+
+@test typeof(node1) == MyCustomNode{Float64,Int}
+@test node1.degree == 0
+@test count_depth(node1) == 1
+@test count_nodes(node1) == 1
+
+node2 = MyCustomNode(1.5, 3, node1)
+
+@test typeof(node2) == MyCustomNode{Float64,Int}
+@test node2.degree == 1
+@test node2.l.degree == 0
+@test count_depth(node2) == 2
+@test count_nodes(node2) == 2
+
+node2 = MyCustomNode(1.5, 3, node1, node1)
+
+@test count_depth(node2) == 2
+@test count_nodes(node2) == 3
+@test sum(t -> t.val1, node2) == 1.5 + 1.0 + 1.0
+@test sum(t -> t.val2, node2) == 3 + 2 + 2
+@test count(t -> t.degree == 0, node2) == 2

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -91,3 +91,7 @@ end
 @safetestset "Test helpers break upon redefining" begin
     include("test_safe_helpers.jl")
 end
+
+@safetestset "Test custom node type" begin
+    include("test_custom_node_type.jl")
+end


### PR DESCRIPTION
This will make it easier to add custom metadata to trees – simply create a new type that inherits from `AbstractNode` with whatever fields are needed.