### PR TITLE
Add built-in random sampling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicExpressions"
 uuid = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -107,6 +107,7 @@ function benchmark_utilities()
         :get_set_constants!,
         :index_constants,
         :string_tree,
+        :hash,
     )
     has_both_modes = [:copy, :convert]
     if PACKAGE_VERSION >= v"0.14.0"
@@ -121,6 +122,9 @@ function benchmark_utilities()
                 :string_tree,
             ],
         )
+    end
+    if PACKAGE_VERSION >= v"0.14.1"
+        append!(has_both_modes, [:hash])
     end
 
     operators = OperatorEnum(; binary_operators=[+, -, /, *], unary_operators=[cos, exp])

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,6 @@
 using Documenter
 using DynamicExpressions
+using Random: AbstractRNG
 
 makedocs(;
     sitename="DynamicExpressions.jl",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,7 @@ makedocs(;
     doctest=false,
     clean=true,
     format=Documenter.HTML(),
+    warnonly=true,
 )
 
 deploydocs(; repo="github.com/SymbolicML/DynamicExpressions.jl.git")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,5 +2,5 @@
 # Contents
 
 ```@contents
-Pages = ["types.md", "eval.md"]
+Pages = ["utils.md", "types.md", "eval.md"]
 ```

--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -20,6 +20,16 @@ convert(::Type{<:AbstractExpressionNode{T1}}, n::AbstractExpressionNode{T2}) whe
 hash(tree::AbstractExpressionNode{T}, h::UInt; break_sharing::Val=Val(false)) where {T}
 ```
 
+## Sampling
+
+There are also methods for random sampling of nodes:
+
+```@docs
+NodeSampler
+rand(rng::AbstractRNG, tree::AbstractNode; break_sharing::Val=Val(false))
+rand(rng::AbstractRNG, sampler::NodeSampler{N,F,Nothing}) where {N,F}
+```
+
 ## Internal utilities
 
 Almost all node utilities are crafted using the `tree_mapreduce` function,

--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -26,7 +26,7 @@ There are also methods for random sampling of nodes:
 
 ```@docs
 NodeSampler
-rand(rng::AbstractRNG, tree::AbstractNode; break_sharing::Val=Val(false))
+rand(rng::AbstractRNG, tree::AbstractNode)
 rand(rng::AbstractRNG, sampler::NodeSampler{N,F,Nothing}) where {N,F}
 ```
 

--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -1,0 +1,36 @@
+# Node utilities
+
+## `Base`
+
+Various functions in `Base` are overloaded to treat an `AbstractNode` as a
+collection of its nodes.
+
+```@docs
+copy(tree::AbstractExpressionNode; break_sharing::Val=Val(false))
+filter(f::Function, tree::AbstractNode; break_sharing::Val=Val(false))
+count(f::Function, tree::AbstractNode; init=0, break_sharing::Val=Val(false))
+foreach(f::Function, tree::AbstractNode; break_sharing::Val=Val(false))
+sum(f::F, tree::AbstractNode; init=0, return_type=Undefined, f_on_shared=_default_shared_aggregation, break_sharing::Val=Val(false)) where {F<:Function}
+mapreduce(f::F, op::G, tree::AbstractNode; return_type, f_on_shared, break_sharing) where {F<:Function,G<:Function}
+any(f::F, tree::AbstractNode) where {F<:Function}
+all(f::F, tree::AbstractNode) where {F<:Function}
+map(f::F, tree::AbstractNode, result_type::Type{RT}=Nothing; break_sharing::Val=Val(false)) where {F<:Function,RT}
+convert(::Type{<:AbstractExpressionNode{T1}}, n::AbstractExpressionNode{T2}) where {T1,T2}
+hash(tree::AbstractExpressionNode{T}, h::UInt; break_sharing::Val=Val(false)) where {T}
+```
+
+## Internal utilities
+
+Almost all node utilities are crafted using the `tree_mapreduce` function,
+which evaluates a mapreduce over a tree-like (or graph-like) structure:
+
+```@docs
+tree_mapreduce
+```
+
+Various other utility functions include the following:
+
+```@docs
+filter_map
+filter_map!
+```

--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -7,6 +7,7 @@ collection of its nodes.
 
 ```@docs
 copy(tree::AbstractExpressionNode; break_sharing::Val=Val(false))
+collect(tree::AbstractNode; break_sharing::Val=Val(false))
 filter(f::Function, tree::AbstractNode; break_sharing::Val=Val(false))
 count(f::Function, tree::AbstractNode; init=0, break_sharing::Val=Val(false))
 foreach(f::Function, tree::AbstractNode; break_sharing::Val=Val(false))

--- a/src/DynamicExpressions.jl
+++ b/src/DynamicExpressions.jl
@@ -24,7 +24,8 @@ import Reexport: @reexport
     copy_node,
     set_node!,
     tree_mapreduce,
-    filter_map
+    filter_map,
+    filter_map!
 import .EquationModule: constructorof, preserve_sharing
 @reexport import .EquationUtilsModule:
     count_nodes,

--- a/src/DynamicExpressions.jl
+++ b/src/DynamicExpressions.jl
@@ -10,6 +10,7 @@ include("EvaluationHelpers.jl")
 include("SimplifyEquation.jl")
 include("OperatorEnumConstruction.jl")
 include("ExtensionInterface.jl")
+include("Random.jl")
 
 import PackageExtensionCompat: @require_extensions
 import Reexport: @reexport
@@ -44,6 +45,7 @@ import .EquationModule: constructorof, preserve_sharing
 @reexport import .SimplifyEquationModule: combine_operators, simplify_tree!
 @reexport import .EvaluationHelpersModule
 @reexport import .ExtensionInterfaceModule: node_to_symbolic, symbolic_to_node
+@reexport import .RandomModule: NodeSampler
 
 function __init__()
     @require_extensions

--- a/src/Random.jl
+++ b/src/Random.jl
@@ -78,9 +78,9 @@ function rand(rng::AbstractRNG, sampler::NodeSampler{N,F,W}) where {N,F,W<:Funct
     return out[]
 end
 function sample_idx(rng::AbstractRNG, weights)
-    normalization = sum(weights)
-    r = rand(rng, typeof(normalization)) * normalization
-    return findfirst(cumsum(weights) .> r)::Int
+    csum = cumsum(weights)
+    r = rand(rng, eltype(weights)) * csum[end]
+    return findfirst(ci -> ci > r, csum)::Int
 end
 
 end

--- a/src/Random.jl
+++ b/src/Random.jl
@@ -75,6 +75,10 @@ function Base.rand(rng::AbstractRNG, sampler::NodeSampler{N,F,W}) where {N,F,W<:
     end
     return out[]
 end
-sample_idx(rng::AbstractRNG, weights) = findfirst(cumsum(weights) .> rand(rng))::Int
+function sample_idx(rng::AbstractRNG, weights)
+    normalization = sum(weights)
+    r = rand(rng, typeof(normalization)) * normalization
+    return findfirst(cumsum(weights) .> r)::Int
+end
 
 end

--- a/src/Random.jl
+++ b/src/Random.jl
@@ -1,0 +1,80 @@
+module RandomModule
+
+import Compat: Returns
+import Random: AbstractRNG
+import ..EquationModule: AbstractNode, tree_mapreduce, filter_map
+
+"""
+    NodeSampler(; tree, filter=Returns(true), weighting=nothing, break_sharing=Val(false))
+
+Defines a sampler of nodes in a tree. `filter` can be used to pre-filter
+nodes on which to sample.
+
+# Arguments
+
+- `tree`: The tree to sample nodes from. For a regular `Node`,
+  nodes are sampled uniformly. For a `GraphNode`, nodes are also
+  sampled uniformly (e.g., in `sin(x) + {x}`, the `x` has equal
+  probability of being sampled from the `sin` or the `+` node, because
+  it is shared), unless `break_sharing` is set to `true` or `Val(true)`.
+- `filter::Function`: A function that takes a node and returns a boolean
+  indicating whether the node should be sampled. Defaults to `Returns(true)`.
+- `weighting::Union{Nothing,Function}`: A function that takes a node and
+  returns a weight for the node, if it passes the filter, proportional
+  to the probability of sampling the node. If `nothing`, all nodes are
+  sampled uniformly.
+- `break_sharing::Union{Bool,Val}`: If `true` or `Val(true)`, the
+  sampler will break sharing in the tree, and sample nodes uniformly
+  from the tree.
+"""
+Base.@kwdef struct NodeSampler{
+    N<:AbstractNode,F<:Function,W<:Union{Nothing,Function},B<:Union{Bool,Val}
+}
+    tree::N
+    weighting::W = nothing
+    filter::F = Returns(true)
+    break_sharing::B = Val(false)
+end
+
+Base.rand(rng::AbstractRNG, tree::AbstractNode) = rand(rng, NodeSampler(; tree))
+function Base.rand(rng::AbstractRNG, sampler::NodeSampler{N,F,Nothing}) where {N,F}
+    break_sharing = if sampler.break_sharing isa Val
+        sampler.break_sharing
+    else
+        sampler.break_sharing ? Val(true) : Val(false)
+    end
+    n = count(sampler.filter, sampler.tree; break_sharing)
+    idx = rand(rng, 1:n)
+    i = Ref(0)
+    out = Ref(sampler.tree)
+    foreach(sampler.tree; break_sharing) do node
+        if @inline(sampler.filter(node)) && (i[] += 1) == idx
+            out[] = node
+        end
+        nothing
+    end
+    return out[]
+end
+function Base.rand(rng::AbstractRNG, sampler::NodeSampler{N,F,W}) where {N,F,W<:Function}
+    break_sharing = if sampler.break_sharing isa Val
+        sampler.break_sharing
+    else
+        sampler.break_sharing ? Val(true) : Val(false)
+    end
+    weights = filter_map(
+        sampler.filter, sampler.weighting, sampler.tree, Float64; break_sharing
+    )
+    idx = sample_idx(rng, weights)
+    i = Ref(0)
+    out = Ref(sampler.tree)
+    foreach(sampler.tree; break_sharing) do node
+        if @inline(sampler.filter(node)) && (i[] += 1) == idx
+            out[] = node
+        end
+        nothing
+    end
+    return out[]
+end
+sample_idx(rng::AbstractRNG, weights) = findfirst(cumsum(weights) .> rand(rng))::Int
+
+end

--- a/src/Random.jl
+++ b/src/Random.jl
@@ -17,7 +17,7 @@ nodes on which to sample.
   nodes are sampled uniformly. For a `GraphNode`, nodes are also
   sampled uniformly (e.g., in `sin(x) + {x}`, the `x` has equal
   probability of being sampled from the `sin` or the `+` node, because
-  it is shared), unless `break_sharing` is set to `true` or `Val(true)`.
+  it is shared), unless `break_sharing` is set to `Val(true)`.
 - `filter::Function`: A function that takes a node and returns a boolean
   indicating whether the node should be sampled. Defaults to `Returns(true)`.
 - `weighting::Union{Nothing,Function}`: A function that takes a node and
@@ -38,11 +38,11 @@ Base.@kwdef struct NodeSampler{
 end
 
 """
-    rand(rng::AbstractRNG, tree::AbstractNode; break_sharing::Val=Val(false))
+    rand(rng::AbstractRNG, tree::AbstractNode)
 
-Sample a node from a tree according to the default sampler `NodeSampler(; tree, break_sharing)`.
+Sample a node from a tree according to the default sampler `NodeSampler(; tree)`.
 """
-rand(rng::AbstractRNG, tree::AbstractNode; break_sharing::Val=Val(false)) = rand(rng, NodeSampler(; tree, break_sharing))
+rand(rng::AbstractRNG, tree::AbstractNode) = rand(rng, NodeSampler(; tree))
 
 """
     rand(rng::AbstractRNG, sampler::NodeSampler)

--- a/src/Random.jl
+++ b/src/Random.jl
@@ -8,8 +8,7 @@ import ..EquationModule: AbstractNode, tree_mapreduce, filter_map
 """
     NodeSampler(; tree, filter::Function=Returns(true), weighting::Union{Nothing,Function}=nothing, break_sharing::Val=Val(false))
 
-Defines a sampler of nodes in a tree. `filter` can be used to pre-filter
-nodes on which to sample.
+Defines a sampler of nodes in a tree.
 
 # Arguments
 

--- a/src/Random.jl
+++ b/src/Random.jl
@@ -1,6 +1,6 @@
 module RandomModule
 
-import Compat: Returns
+import Compat: Returns, @inline
 import Random: AbstractRNG
 import Base: rand
 import ..EquationModule: AbstractNode, tree_mapreduce, filter_map

--- a/src/Random.jl
+++ b/src/Random.jl
@@ -2,10 +2,11 @@ module RandomModule
 
 import Compat: Returns
 import Random: AbstractRNG
+import Base: rand
 import ..EquationModule: AbstractNode, tree_mapreduce, filter_map
 
 """
-    NodeSampler(; tree, filter=Returns(true), weighting=nothing, break_sharing=Val(false))
+    NodeSampler(; tree, filter::Function=Returns(true), weighting::Union{Nothing,Function}=nothing, break_sharing::Val=Val(false))
 
 Defines a sampler of nodes in a tree. `filter` can be used to pre-filter
 nodes on which to sample.
@@ -23,12 +24,12 @@ nodes on which to sample.
   returns a weight for the node, if it passes the filter, proportional
   to the probability of sampling the node. If `nothing`, all nodes are
   sampled uniformly.
-- `break_sharing::Union{Bool,Val}`: If `true` or `Val(true)`, the
+- `break_sharing::Val`: If `Val(true)`, the
   sampler will break sharing in the tree, and sample nodes uniformly
   from the tree.
 """
 Base.@kwdef struct NodeSampler{
-    N<:AbstractNode,F<:Function,W<:Union{Nothing,Function},B<:Union{Bool,Val}
+    N<:AbstractNode,F<:Function,W<:Union{Nothing,Function},B<:Val
 }
     tree::N
     weighting::W = nothing
@@ -36,18 +37,24 @@ Base.@kwdef struct NodeSampler{
     break_sharing::B = Val(false)
 end
 
-Base.rand(rng::AbstractRNG, tree::AbstractNode) = rand(rng, NodeSampler(; tree))
-function Base.rand(rng::AbstractRNG, sampler::NodeSampler{N,F,Nothing}) where {N,F}
-    break_sharing = if sampler.break_sharing isa Val
-        sampler.break_sharing
-    else
-        sampler.break_sharing ? Val(true) : Val(false)
-    end
-    n = count(sampler.filter, sampler.tree; break_sharing)
+"""
+    rand(rng::AbstractRNG, tree::AbstractNode; break_sharing::Val=Val(false))
+
+Sample a node from a tree according to the default sampler `NodeSampler(; tree, break_sharing)`.
+"""
+rand(rng::AbstractRNG, tree::AbstractNode; break_sharing::Val=Val(false)) = rand(rng, NodeSampler(; tree, break_sharing))
+
+"""
+    rand(rng::AbstractRNG, sampler::NodeSampler)
+
+Sample a node from a tree according to the sampler `sampler`.
+"""
+function rand(rng::AbstractRNG, sampler::NodeSampler{N,F,Nothing}) where {N,F}
+    n = count(sampler.filter, sampler.tree; sampler.break_sharing)
     idx = rand(rng, 1:n)
     i = Ref(0)
     out = Ref(sampler.tree)
-    foreach(sampler.tree; break_sharing) do node
+    foreach(sampler.tree; sampler.break_sharing) do node
         if @inline(sampler.filter(node)) && (i[] += 1) == idx
             out[] = node
         end
@@ -55,19 +62,14 @@ function Base.rand(rng::AbstractRNG, sampler::NodeSampler{N,F,Nothing}) where {N
     end
     return out[]
 end
-function Base.rand(rng::AbstractRNG, sampler::NodeSampler{N,F,W}) where {N,F,W<:Function}
-    break_sharing = if sampler.break_sharing isa Val
-        sampler.break_sharing
-    else
-        sampler.break_sharing ? Val(true) : Val(false)
-    end
+function rand(rng::AbstractRNG, sampler::NodeSampler{N,F,W}) where {N,F,W<:Function}
     weights = filter_map(
-        sampler.filter, sampler.weighting, sampler.tree, Float64; break_sharing
+        sampler.filter, sampler.weighting, sampler.tree, Float64; sampler.break_sharing
     )
     idx = sample_idx(rng, weights)
     i = Ref(0)
     out = Ref(sampler.tree)
-    foreach(sampler.tree; break_sharing) do node
+    foreach(sampler.tree; sampler.break_sharing) do node
         if @inline(sampler.filter(node)) && (i[] += 1) == idx
             out[] = node
         end

--- a/src/base.jl
+++ b/src/base.jl
@@ -294,6 +294,11 @@ function filter(f::F, tree::AbstractNode; break_sharing::Val=Val(false)) where {
     return filter_map(f, identity, tree, typeof(tree); break_sharing)
 end
 
+"""
+    collect(tree::AbstractNode; break_sharing::Val=Val(false))
+
+Collect all nodes in a tree into a flat array in depth-first order.
+"""
 function collect(tree::AbstractNode; break_sharing::Val=Val(false))
     return filter(Returns(true), tree; break_sharing)
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -407,7 +407,9 @@ end
 Compute a hash of a tree. This will compute a hash differently
 if nodes are shared in a tree. This is ignored if `break_sharing` is set to `Val(true)`.
 """
-function hash(tree::AbstractExpressionNode{T}, h::UInt=zero(UInt); break_sharing::Val=Val(false)) where {T}
+function hash(
+    tree::AbstractExpressionNode{T}, h::UInt=zero(UInt); break_sharing::Val=Val(false)
+) where {T}
     return tree_mapreduce(
         t -> t.constant ? hash((0, t.val::T), h) : hash((1, t.feature), h),
         t -> hash((t.degree + 1, t.op), h),

--- a/test/test_random.jl
+++ b/test/test_random.jl
@@ -23,18 +23,16 @@ atol = 200
     @test isapprox(num_cos, num_samples ÷ 3; atol)
 
     # Now, we sample without sharing
-    for break_sharing in (true, Val(true))
-        broken_sharing_samples = let rng = Random.MersenneTwister(0)
-            [rand(rng, NodeSampler(; tree, break_sharing)) for _ in 1:num_samples]
-        end
-        num_plus = count(Base.Fix1(===, tree), broken_sharing_samples)
-        num_x = count(Base.Fix1(===, x), broken_sharing_samples)
-        num_cos = count(Base.Fix1(===, tree.l), broken_sharing_samples)
-
-        @test isapprox(num_plus, num_samples ÷ 4; atol)
-        @test isapprox(num_x, num_samples ÷ 2; atol)
-        @test isapprox(num_cos, num_samples ÷ 4; atol)
+    broken_sharing_samples = let rng = Random.MersenneTwister(0)
+        [rand(rng, NodeSampler(; tree, break_sharing=Val(true))) for _ in 1:num_samples]
     end
+    num_plus = count(Base.Fix1(===, tree), broken_sharing_samples)
+    num_x = count(Base.Fix1(===, x), broken_sharing_samples)
+    num_cos = count(Base.Fix1(===, tree.l), broken_sharing_samples)
+
+    @test isapprox(num_plus, num_samples ÷ 4; atol)
+    @test isapprox(num_x, num_samples ÷ 2; atol)
+    @test isapprox(num_cos, num_samples ÷ 4; atol)
 end
 
 @testset "Weighted sampling" begin
@@ -68,19 +66,16 @@ end
             5.0
         end
     end
-    for break_sharing in (true, Val(true))
-        broken_sharing_weighted_samples = let rng = Random.MersenneTwister(0)
-            [
-                rand(rng, NodeSampler(; tree, weighting=weighting_2, break_sharing)) for
-                _ in 1:num_samples
-            ]
-        end
-        num_plus = count(Base.Fix1(===, tree), broken_sharing_weighted_samples)
-        num_x = count(Base.Fix1(===, x), broken_sharing_weighted_samples)
-        num_cos = count(Base.Fix1(===, tree.l), broken_sharing_weighted_samples)
-
-        @test isapprox(num_plus, num_samples * 5 ÷ 100; atol)
-        @test isapprox(num_x, num_samples * 20 ÷ 100; atol)
-        @test isapprox(num_cos, num_samples * 75 ÷ 100; atol)
+    broken_sharing_weighted_samples = let rng = Random.MersenneTwister(0)
+        [
+            rand(rng, NodeSampler(; tree, weighting=weighting_2, break_sharing=Val(true))) for _ in 1:num_samples
+        ]
     end
+    num_plus = count(Base.Fix1(===, tree), broken_sharing_weighted_samples)
+    num_x = count(Base.Fix1(===, x), broken_sharing_weighted_samples)
+    num_cos = count(Base.Fix1(===, tree.l), broken_sharing_weighted_samples)
+
+    @test isapprox(num_plus, num_samples * 5 ÷ 100; atol)
+    @test isapprox(num_x, num_samples * 20 ÷ 100; atol)
+    @test isapprox(num_cos, num_samples * 75 ÷ 100; atol)
 end

--- a/test/test_random.jl
+++ b/test/test_random.jl
@@ -23,16 +23,18 @@ atol = 200
     @test isapprox(num_cos, num_samples ÷ 3; atol)
 
     # Now, we sample without sharing
-    broken_sharing_samples = let rng = Random.MersenneTwister(0)
-        [rand(rng, NodeSampler(; tree, break_sharing=Val(true))) for _ in 1:num_samples]
-    end
-    num_plus = count(Base.Fix1(===, tree), broken_sharing_samples)
-    num_x = count(Base.Fix1(===, x), broken_sharing_samples)
-    num_cos = count(Base.Fix1(===, tree.l), broken_sharing_samples)
+    for break_sharing in (true, Val(true))
+        broken_sharing_samples = let rng = Random.MersenneTwister(0)
+            [rand(rng, NodeSampler(; tree, break_sharing)) for _ in 1:num_samples]
+        end
+        num_plus = count(Base.Fix1(===, tree), broken_sharing_samples)
+        num_x = count(Base.Fix1(===, x), broken_sharing_samples)
+        num_cos = count(Base.Fix1(===, tree.l), broken_sharing_samples)
 
-    @test isapprox(num_plus, num_samples ÷ 4; atol)
-    @test isapprox(num_x, num_samples ÷ 2; atol)
-    @test isapprox(num_cos, num_samples ÷ 4; atol)
+        @test isapprox(num_plus, num_samples ÷ 4; atol)
+        @test isapprox(num_x, num_samples ÷ 2; atol)
+        @test isapprox(num_cos, num_samples ÷ 4; atol)
+    end
 end
 
 @testset "Weighted sampling" begin
@@ -66,16 +68,19 @@ end
             5.0
         end
     end
-    broken_sharing_weighted_samples = let rng = Random.MersenneTwister(0)
-        [
-            rand(rng, NodeSampler(; tree, weighting=weighting_2, break_sharing=Val(true))) for _ in 1:num_samples
-        ]
-    end
-    num_plus = count(Base.Fix1(===, tree), broken_sharing_weighted_samples)
-    num_x = count(Base.Fix1(===, x), broken_sharing_weighted_samples)
-    num_cos = count(Base.Fix1(===, tree.l), broken_sharing_weighted_samples)
+    for break_sharing in (true, Val(true))
+        broken_sharing_weighted_samples = let rng = Random.MersenneTwister(0)
+            [
+                rand(rng, NodeSampler(; tree, weighting=weighting_2, break_sharing)) for
+                _ in 1:num_samples
+            ]
+        end
+        num_plus = count(Base.Fix1(===, tree), broken_sharing_weighted_samples)
+        num_x = count(Base.Fix1(===, x), broken_sharing_weighted_samples)
+        num_cos = count(Base.Fix1(===, tree.l), broken_sharing_weighted_samples)
 
-    @test isapprox(num_plus, num_samples * 5 ÷ 100; atol)
-    @test isapprox(num_x, num_samples * 20 ÷ 100; atol)
-    @test isapprox(num_cos, num_samples * 75 ÷ 100; atol)
+        @test isapprox(num_plus, num_samples * 5 ÷ 100; atol)
+        @test isapprox(num_x, num_samples * 20 ÷ 100; atol)
+        @test isapprox(num_cos, num_samples * 75 ÷ 100; atol)
+    end
 end

--- a/test/test_random.jl
+++ b/test/test_random.jl
@@ -1,0 +1,81 @@
+using DynamicExpressions
+using Random
+using Test
+
+operators = OperatorEnum(; binary_operators=[+, -, *, /], unary_operators=[cos, sin])
+x = GraphNode(Float64; feature=1)
+tree = cos(x) + x
+
+num_samples = 10_000
+atol = 200
+
+@testset "Basic random sampling" begin
+    uniform_samples = let rng = Random.MersenneTwister(0)
+        [rand(rng, tree) for _ in 1:num_samples]
+    end
+
+    num_plus = count(Base.Fix1(===, tree), uniform_samples)
+    num_x = count(Base.Fix1(===, x), uniform_samples)
+    num_cos = count(Base.Fix1(===, tree.l), uniform_samples)
+
+    @test isapprox(num_plus, num_samples ÷ 3; atol)
+    @test isapprox(num_x, num_samples ÷ 3; atol)
+    @test isapprox(num_cos, num_samples ÷ 3; atol)
+
+    # Now, we sample without sharing
+    broken_sharing_samples = let rng = Random.MersenneTwister(0)
+        [rand(rng, NodeSampler(; tree, break_sharing=Val(true))) for _ in 1:num_samples]
+    end
+    num_plus = count(Base.Fix1(===, tree), broken_sharing_samples)
+    num_x = count(Base.Fix1(===, x), broken_sharing_samples)
+    num_cos = count(Base.Fix1(===, tree.l), broken_sharing_samples)
+
+    @test isapprox(num_plus, num_samples ÷ 4; atol)
+    @test isapprox(num_x, num_samples ÷ 2; atol)
+    @test isapprox(num_cos, num_samples ÷ 4; atol)
+end
+
+@testset "Weighted sampling" begin
+    function weighting_1(t)
+        if t == cos(x)
+            75.0
+        elseif t == x
+            10.0
+        else
+            15.0
+        end
+    end
+    specific_weighted_samples = let rng = Random.MersenneTwister(0)
+        [rand(rng, NodeSampler(; tree, weighting=weighting_1)) for _ in 1:num_samples]
+    end
+    num_plus = count(Base.Fix1(===, tree), specific_weighted_samples)
+    num_x = count(Base.Fix1(===, x), specific_weighted_samples)
+    num_cos = count(Base.Fix1(===, tree.l), specific_weighted_samples)
+
+    @test isapprox(num_plus, num_samples * 15 ÷ 100; atol)
+    @test isapprox(num_x, num_samples * 10 ÷ 100; atol)
+    @test isapprox(num_cos, num_samples * 75 ÷ 100; atol)
+
+    # Now, without sharing
+    function weighting_2(t)
+        if t == cos(x)
+            75.0
+        elseif t == x
+            10.0  # Will be doubled if we break sharing
+        else
+            5.0
+        end
+    end
+    broken_sharing_weighted_samples = let rng = Random.MersenneTwister(0)
+        [
+            rand(rng, NodeSampler(; tree, weighting=weighting_2, break_sharing=Val(true))) for _ in 1:num_samples
+        ]
+    end
+    num_plus = count(Base.Fix1(===, tree), broken_sharing_weighted_samples)
+    num_x = count(Base.Fix1(===, x), broken_sharing_weighted_samples)
+    num_cos = count(Base.Fix1(===, tree.l), broken_sharing_weighted_samples)
+
+    @test isapprox(num_plus, num_samples * 5 ÷ 100; atol)
+    @test isapprox(num_x, num_samples * 20 ÷ 100; atol)
+    @test isapprox(num_cos, num_samples * 75 ÷ 100; atol)
+end

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -95,3 +95,7 @@ end
 @safetestset "Test custom node type" begin
     include("test_custom_node_type.jl")
 end
+
+@safetestset "Test random sampling" begin
+    include("test_random.jl")
+end


### PR DESCRIPTION
This moves all the random sampling of nodes into DynamicExpressions.jl. It also makes things more explicit with respect to sampling graph nodes. For example, should one sample a `GraphNode` with the same probability, or proportional to how many times it is used in upstream nodes? This allows you to choose both.

TODO:

- [x] Add `NodeSampler` to docs