### PR TITLE
Enforce `Vararg` specialization

### DIFF
--- a/src/EquationUtils.jl
+++ b/src/EquationUtils.jl
@@ -18,9 +18,13 @@ import ..EquationModule:
 
 Compute the max depth of the tree.
 """
-function count_depth(tree::AbstractNode)
+function count_depth(tree::N) where {N<:AbstractNode}
     return tree_mapreduce(
-        Returns(1), (p, child...) -> p + max(child...), tree, Int64; break_sharing=Val(true)
+        Returns(1),
+        ((p, child::Vararg{Int64,M}) where {M}) -> p + max(child...),
+        tree,
+        Int64;
+        break_sharing=Val(true),
     )
 end
 
@@ -119,7 +123,7 @@ end
 # as we trace over the node we are indexing on.
 preserve_sharing(::Type{<:NodeIndex}) = false
 
-function index_constants(tree::AbstractExpressionNode, ::Type{T}=UInt16) where {T}
+function index_constants(tree::N, ::Type{T}=UInt16) where {T,N<:AbstractExpressionNode}
     # Essentially we copy the tree, replacing the values
     # with indices
     constant_index = Ref(T(0))
@@ -130,7 +134,7 @@ function index_constants(tree::AbstractExpressionNode, ::Type{T}=UInt16) where {
             NodeIndex(T)
         end,
         t -> nothing,
-        (_, c...) -> NodeIndex(T, c...),
+        ((_, c::Vararg{NodeIndex{T},M}) where {M}) -> NodeIndex(T, c...),
         tree,
         NodeIndex{T};
     )

--- a/src/EvaluateEquationDerivative.jl
+++ b/src/EvaluateEquationDerivative.jl
@@ -311,7 +311,7 @@ function grad_deg0_eval(
     zero_mat = if typeof(cX) <: Array
         zeros(T, n_gradients, size(cX, 2))
     else
-        hcat((fill_similar(zero(T), cX, axes(cX, 2)) for _ in 1:n_gradients)...)'
+        hcat(ntuple(_ -> fill_similar(zero(T), cX, axes(cX, 2)), Val(n_gradients))...)'
     end
 
     if variable == tree.constant

--- a/src/EvaluationHelpers.jl
+++ b/src/EvaluationHelpers.jl
@@ -93,6 +93,6 @@ to every constant in the expression.
     the gradient, and whether the evaluation completed as normal (or encountered a nan or inf).
 """
 Base.adjoint(tree::AbstractExpressionNode) =
-    ((args...; kws...) -> _grad_evaluator(tree, args...; kws...))
+    (((args::Vararg{Any,M}; kws...) where {M}) -> _grad_evaluator(tree, args...; kws...))
 
 end

--- a/src/SimplifyEquation.jl
+++ b/src/SimplifyEquation.jl
@@ -108,7 +108,9 @@ function combine_operators(tree::Node{T}, operators::AbstractOperatorEnum) where
     return tree
 end
 
-function combine_children!(operators, p::N, c::N...) where {T,N<:AbstractExpressionNode{T}}
+function combine_children!(
+    operators, p::N, c::Vararg{N,M}
+) where {T,N<:AbstractExpressionNode{T},M}
     all(is_node_constant, c) || return p
     vals = map(n -> n.val::T, c)
     all(isgood, vals) || return p
@@ -124,10 +126,12 @@ function combine_children!(operators, p::N, c::N...) where {T,N<:AbstractExpress
 end
 
 # Simplify tree
-function simplify_tree!(tree::AbstractExpressionNode, operators::AbstractOperatorEnum)
+function simplify_tree!(
+    tree::N, operators::AbstractOperatorEnum
+) where {N<:AbstractExpressionNode}
     tree = tree_mapreduce(
         identity,
-        (p, c...) -> combine_children!(operators, p, c...),
+        ((p, c::Vararg{N,M}) where {M}) -> combine_children!(operators, p, c...),
         tree,
         constructorof(typeof(tree));
     )

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -177,7 +177,7 @@ function _add_idmap_to_call(def::Expr, id_map::Union{Symbol,Expr})
     return Expr(:call, def.args[1], def.args[2:end]..., id_map)
 end
 
-@inline function fill_similar(value, array, args...)
+@inline function fill_similar(value, array, args::Vararg{Any,M}) where {M}
     out_array = similar(array, args...)
     fill!(out_array, value)
     return out_array

--- a/src/base.jl
+++ b/src/base.jl
@@ -174,7 +174,7 @@ function inner_is_equal_shared(a, b, id_map_a, id_map_b)
 
     if has_a && has_b
         return true
-    elseif has_a ⊻ has_b
+    elseif has_a != has_b
         return false
     end
 


### PR DESCRIPTION
I didn't realize this but apparently Julia doesn't actually specialize functions based on variable numbers of arguments.

There's a way to get around this as described here: https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing.

This PR implements this forced specialization which should hopefully give some speedups.