### PR TITLE
fix: non-finite `.val` evaluation issue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicExpressions"
 uuid = "a40a106e-89c9-4ca8-8020-a735e8728b6b"
 authors = ["MilesCranmer <miles.cranmer@gmail.com>"]
-version = "1.5.0"
+version = "1.5.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/Evaluate.jl
+++ b/src/Evaluate.jl
@@ -621,7 +621,7 @@ end
 
 @inline function deg0_eval_constant(tree::AbstractExpressionNode{T}) where {T}
     output = tree.val
-    return ResultOk([output], true)::ResultOk{Vector{T}}
+    return ResultOk([output], is_valid(output))::ResultOk{Vector{T}}
 end
 
 function deg1_eval_constant(


### PR DESCRIPTION
Should fix https://github.com/MilesCranmer/PySR/issues/759 by @GoldenGoldy

This also includes a test that randomly generates trees and fills their `.val` with `Inf` or `NaN`. This test failed before this fix (which is bad!) but now passes.