### PR TITLE
Zero-allocation tree evaluation with buffer

### DIFF
--- a/ext/DynamicExpressionsLoopVectorizationExt.jl
+++ b/ext/DynamicExpressionsLoopVectorizationExt.jl
@@ -57,7 +57,7 @@ function deg1_l2_ll0_lr0_eval(
         @return_on_nonfinite_val(eval_options, x_l, cX)
         x = op(x_l)::T
         @return_on_nonfinite_val(eval_options, x, cX)
-        return ResultOk(get_filled_array(eval_options.buffer, x, cX, axes(cX, 2)))
+        return ResultOk(get_filled_array(eval_options.buffer, x, cX, axes(cX, 2)), true)
     elseif tree.l.l.constant
         val_ll = tree.l.l.val
         @return_on_nonfinite_val(eval_options, val_ll, cX)
@@ -107,7 +107,7 @@ function deg1_l1_ll0_eval(
         @return_on_nonfinite_val(eval_options, x_l, cX)
         x = op(x_l)::T
         @return_on_nonfinite_val(eval_options, x, cX)
-        return ResultOk(get_filled_array(eval_options.buffer, x, cX, axes(cX, 2)))
+        return ResultOk(get_filled_array(eval_options.buffer, x, cX, axes(cX, 2)), true)
     else
         feature_ll = tree.l.l.feature
         cumulator = get_array(eval_options.buffer, cX, axes(cX, 2))
@@ -133,7 +133,7 @@ function deg2_l0_r0_eval(
         @return_on_nonfinite_val(eval_options, val_r, cX)
         x = op(val_l, val_r)::T
         @return_on_nonfinite_val(eval_options, x, cX)
-        return ResultOk(get_filled_array(eval_options.buffer, x, cX, axes(cX, 2)))
+        return ResultOk(get_filled_array(eval_options.buffer, x, cX, axes(cX, 2)), true)
     elseif tree.l.constant
         cumulator = get_array(eval_options.buffer, cX, axes(cX, 2))
         val_l = tree.l.val

--- a/ext/DynamicExpressionsLoopVectorizationExt.jl
+++ b/ext/DynamicExpressionsLoopVectorizationExt.jl
@@ -2,8 +2,9 @@ module DynamicExpressionsLoopVectorizationExt
 
 using LoopVectorization: @turbo
 using DynamicExpressions: AbstractExpressionNode
-using DynamicExpressions.UtilsModule: ResultOk, fill_similar
-using DynamicExpressions.EvaluateModule: @return_on_nonfinite_val, EvalOptions
+using DynamicExpressions.UtilsModule: ResultOk
+using DynamicExpressions.EvaluateModule:
+    @return_on_nonfinite_val, EvalOptions, get_array, get_feature_array, get_filled_array
 import DynamicExpressions.EvaluateModule:
     deg1_eval,
     deg2_eval,
@@ -56,12 +57,12 @@ function deg1_l2_ll0_lr0_eval(
         @return_on_nonfinite_val(eval_options, x_l, cX)
         x = op(x_l)::T
         @return_on_nonfinite_val(eval_options, x, cX)
-        return ResultOk(fill_similar(x, cX, axes(cX, 2)), true)
+        return ResultOk(get_filled_array(eval_options.buffer, x, cX, axes(cX, 2)))
     elseif tree.l.l.constant
         val_ll = tree.l.l.val
         @return_on_nonfinite_val(eval_options, val_ll, cX)
         feature_lr = tree.l.r.feature
-        cumulator = similar(cX, axes(cX, 2))
+        cumulator = get_array(eval_options.buffer, cX, axes(cX, 2))
         @turbo for j in axes(cX, 2)
             x_l = op_l(val_ll, cX[feature_lr, j])
             x = op(x_l)
@@ -72,7 +73,7 @@ function deg1_l2_ll0_lr0_eval(
         feature_ll = tree.l.l.feature
         val_lr = tree.l.r.val
         @return_on_nonfinite_val(eval_options, val_lr, cX)
-        cumulator = similar(cX, axes(cX, 2))
+        cumulator = get_array(eval_options.buffer, cX, axes(cX, 2))
         @turbo for j in axes(cX, 2)
             x_l = op_l(cX[feature_ll, j], val_lr)
             x = op(x_l)
@@ -82,7 +83,7 @@ function deg1_l2_ll0_lr0_eval(
     else
         feature_ll = tree.l.l.feature
         feature_lr = tree.l.r.feature
-        cumulator = similar(cX, axes(cX, 2))
+        cumulator = get_array(eval_options.buffer, cX, axes(cX, 2))
         @turbo for j in axes(cX, 2)
             x_l = op_l(cX[feature_ll, j], cX[feature_lr, j])
             x = op(x_l)
@@ -106,10 +107,10 @@ function deg1_l1_ll0_eval(
         @return_on_nonfinite_val(eval_options, x_l, cX)
         x = op(x_l)::T
         @return_on_nonfinite_val(eval_options, x, cX)
-        return ResultOk(fill_similar(x, cX, axes(cX, 2)), true)
+        return ResultOk(get_filled_array(eval_options.buffer, x, cX, axes(cX, 2)))
     else
         feature_ll = tree.l.l.feature
-        cumulator = similar(cX, axes(cX, 2))
+        cumulator = get_array(eval_options.buffer, cX, axes(cX, 2))
         @turbo for j in axes(cX, 2)
             x_l = op_l(cX[feature_ll, j])
             x = op(x_l)
@@ -132,9 +133,9 @@ function deg2_l0_r0_eval(
         @return_on_nonfinite_val(eval_options, val_r, cX)
         x = op(val_l, val_r)::T
         @return_on_nonfinite_val(eval_options, x, cX)
-        return ResultOk(fill_similar(x, cX, axes(cX, 2)), true)
+        return ResultOk(get_filled_array(eval_options.buffer, x, cX, axes(cX, 2)))
     elseif tree.l.constant
-        cumulator = similar(cX, axes(cX, 2))
+        cumulator = get_array(eval_options.buffer, cX, axes(cX, 2))
         val_l = tree.l.val
         @return_on_nonfinite_val(eval_options, val_l, cX)
         feature_r = tree.r.feature
@@ -144,7 +145,7 @@ function deg2_l0_r0_eval(
         end
         return ResultOk(cumulator, true)
     elseif tree.r.constant
-        cumulator = similar(cX, axes(cX, 2))
+        cumulator = get_array(eval_options.buffer, cX, axes(cX, 2))
         feature_l = tree.l.feature
         val_r = tree.r.val
         @return_on_nonfinite_val(eval_options, val_r, cX)
@@ -154,7 +155,7 @@ function deg2_l0_r0_eval(
         end
         return ResultOk(cumulator, true)
     else
-        cumulator = similar(cX, axes(cX, 2))
+        cumulator = get_array(eval_options.buffer, cX, axes(cX, 2))
         feature_l = tree.l.feature
         feature_r = tree.r.feature
         @turbo for j in axes(cX, 2)

--- a/src/DynamicExpressions.jl
+++ b/src/DynamicExpressions.jl
@@ -73,6 +73,7 @@ import .StringsModule: get_op_name
     OperatorEnum, GenericOperatorEnum, @extend_operators, set_default_variable_names!
 @reexport import .EvaluateModule:
     eval_tree_array, differentiable_eval_tree_array, EvalOptions
+import .EvaluateModule: ArrayBuffer
 @reexport import .EvaluateDerivativeModule: eval_diff_tree_array, eval_grad_tree_array
 @reexport import .ChainRulesModule: NodeTangent, extract_gradient
 @reexport import .SimplifyModule: combine_operators, simplify_tree!

--- a/src/Evaluate.jl
+++ b/src/Evaluate.jl
@@ -56,19 +56,17 @@ function get_filled_array(::Nothing, value, template::AbstractArray, axes...)
 end
 function get_filled_array(buffer::ArrayBuffer, value, template::AbstractArray, axes...)
     i = next_index!(buffer)
-    out = @view(buffer.array[i, :])
-    out .= value
-    return out
+    @inbounds buffer.array[i, :] .= value
+    return @view(buffer.array[i, :])
 end
 
 function get_feature_array(::Nothing, X::AbstractMatrix, feature::Integer)
-    return X[feature, :]
+    return @inbounds(X[feature, :])
 end
 function get_feature_array(buffer::ArrayBuffer, X::AbstractMatrix, feature::Integer)
     i = next_index!(buffer)
-    out = @view(buffer.array[i, :])
-    out .= X[feature, :]
-    return out
+    @inbounds buffer.array[i, :] .= X[feature, :]
+    return @view(buffer.array[i, :])
 end
 
 """

--- a/src/Evaluate.jl
+++ b/src/Evaluate.jl
@@ -229,7 +229,6 @@ function eval_tree_array(
     kws...,
 ) where {T1,T2}
     T = promote_type(T1, T2)
-    @warn "Warning: eval_tree_array received mixed types: tree=$(T1) and data=$(T2)."
     tree = convert(constructorof(typeof(tree)){T}, tree)
     cX = Base.Fix1(convert, T).(cX)
     return eval_tree_array(tree, cX, operators; kws...)

--- a/src/Evaluate.jl
+++ b/src/Evaluate.jl
@@ -70,7 +70,7 @@ function get_feature_array(buffer::ArrayBuffer, X::AbstractMatrix, feature::Inte
 end
 
 """
-    EvalOptions{T,B,E}
+    EvalOptions
 
 This holds options for expression evaluation, such as evaluation backend.
 
@@ -86,8 +86,10 @@ This holds options for expression evaluation, such as evaluation backend.
     the entire buffer. This early exit is performed to avoid wasting compute cycles.
     Setting `Val{false}` will continue the computation as usual and thus result in
     `NaN`s only in the elements that actually have `NaN`s.
+- `buffer::Union{ArrayBuffer,Nothing}`: If not `nothing`, use this buffer for evaluation.
+    This should be an instance of `ArrayBuffer` which has an `array` field and an
+    `index` field used to iterate which buffer slot to use.
 """
-
 struct EvalOptions{T,B,E,BUF<:Union{ArrayBuffer,Nothing}}
     turbo::Val{T}
     bumper::Val{B}
@@ -99,24 +101,17 @@ end
     turbo::Union{Bool,Val}=Val(false),
     bumper::Union{Bool,Val}=Val(false),
     early_exit::Union{Bool,Val}=Val(true),
-    buffer::Union{AbstractMatrix,Nothing}=nothing,
-    buffer_ref::Union{Base.RefValue{<:Integer},Nothing}=nothing,
+    buffer::Union{ArrayBuffer,Nothing}=nothing,
 )
     v_turbo = _to_bool_val(turbo)
     v_bumper = _to_bool_val(bumper)
     v_early_exit = _to_bool_val(early_exit)
 
     if v_bumper isa Val{true}
-        @assert buffer === nothing && buffer_ref === nothing
+        @assert buffer === nothing
     end
 
-    array_buffer = if buffer === nothing
-        nothing
-    else
-        ArrayBuffer(buffer, buffer_ref)
-    end
-
-    return EvalOptions(v_turbo, v_bumper, v_early_exit, array_buffer)
+    return EvalOptions(v_turbo, v_bumper, v_early_exit, buffer)
 end
 
 @unstable @inline _to_bool_val(x::Bool) = x ? Val(true) : Val(false)

--- a/src/Evaluate.jl
+++ b/src/Evaluate.jl
@@ -106,7 +106,7 @@ end
     v_bumper = _to_bool_val(bumper)
     v_early_exit = _to_bool_val(early_exit)
 
-    if v_turbo isa Val{true} || v_bumper isa Val{true}
+    if v_bumper isa Val{true}
         @assert buffer === nothing && buffer_ref === nothing
     end
 

--- a/src/EvaluateDerivative.jl
+++ b/src/EvaluateDerivative.jl
@@ -5,7 +5,8 @@ import ..OperatorEnumModule: OperatorEnum
 import ..UtilsModule: fill_similar, ResultOk2
 import ..ValueInterfaceModule: is_valid_array
 import ..NodeUtilsModule: count_constant_nodes, index_constant_nodes, NodeIndex
-import ..EvaluateModule: deg0_eval, get_nuna, get_nbin, OPERATOR_LIMIT_BEFORE_SLOWDOWN
+import ..EvaluateModule:
+    deg0_eval, get_nuna, get_nbin, OPERATOR_LIMIT_BEFORE_SLOWDOWN, EvalOptions
 import ..ExtensionInterfaceModule: _zygote_gradient
 
 """
@@ -120,7 +121,7 @@ end
 function diff_deg0_eval(
     tree::AbstractExpressionNode{T}, cX::AbstractMatrix{T}, direction::Integer
 ) where {T<:Number}
-    const_part = deg0_eval(tree, cX).x
+    const_part = deg0_eval(tree, cX, EvalOptions()).x
     derivative_part = if ((!tree.constant) && tree.feature == direction)
         fill_similar(one(T), cX, axes(cX, 2))
     else
@@ -335,7 +336,7 @@ function grad_deg0_eval(
     cX::AbstractMatrix{T},
     ::Val{mode},
 )::ResultOk2 where {T<:Number,mode}
-    const_part = deg0_eval(tree, cX).x
+    const_part = deg0_eval(tree, cX, EvalOptions()).x
 
     zero_mat = if isa(cX, Array)
         fill_similar(zero(T), cX, n_gradients, axes(cX, 2))

--- a/test/test_buffered_evaluation.jl
+++ b/test/test_buffered_evaluation.jl
@@ -15,10 +15,7 @@
     @test eval_options.buffer.array === buffer
     @test eval_options.buffer.index === buffer_ref
 
-    # Test buffer is not allowed with turbo/bumper
-    @test_throws AssertionError EvalOptions(;
-        turbo=true, buffer=buffer, buffer_ref=buffer_ref
-    )
+    # Test buffer is not allowed with bumper
     @test_throws AssertionError EvalOptions(;
         bumper=true, buffer=buffer, buffer_ref=buffer_ref
     )
@@ -135,7 +132,9 @@ end
 
         # Regular evaluation
         eval_options_no_buffer = EvalOptions(; turbo)
-        result1, ok1 = eval_tree_array(tree, X, operators; eval_options=eval_options_no_buffer)
+        result1, ok1 = eval_tree_array(
+            tree, X, operators; eval_options=eval_options_no_buffer
+        )
 
         # Buffer evaluation
         buffer = Array{Float64}(undef, 2n_nodes, size(X, 2))

--- a/test/test_buffered_evaluation.jl
+++ b/test/test_buffered_evaluation.jl
@@ -1,0 +1,121 @@
+@testitem "Buffer creation and validation" begin
+    using DynamicExpressions
+    using Test
+
+    # Test data setup
+    X = rand(2, 10)  # 2 features, 10 samples
+    operators = OperatorEnum(; binary_operators=[+, *], unary_operators=[sin])
+    tree = Node(;
+        op=2, l=Node(; op=1, l=Node(Float64; feature=1)), r=Node(Float64; val=2.0)
+    )
+
+    # Basic buffer creation - buffer shape should match (num_leafs, num_samples)
+    buffer = zeros(5, size(X, 2))  # 5 leaves should be enough for our test tree
+    buffer_ref = Ref(0)
+    eval_options = EvalOptions(; buffer=buffer, buffer_ref=buffer_ref)
+    @test eval_options.buffer.array === buffer
+    @test eval_options.buffer.index === buffer_ref
+
+    # Test buffer is not allowed with turbo/bumper
+    @test_throws AssertionError EvalOptions(;
+        turbo=true, buffer=buffer, buffer_ref=buffer_ref
+    )
+    @test_throws AssertionError EvalOptions(;
+        bumper=true, buffer=buffer, buffer_ref=buffer_ref
+    )
+
+    # Basic evaluation should work
+    result = eval_tree_array(tree, X, operators; eval_options)
+    @test length(result) == 2  # Returns (output, ok)
+    @test size(result[1]) == (size(X, 2),)  # Output should match number of samples
+end
+
+@testitem "Buffer correctness" begin
+    using DynamicExpressions
+    using Test
+
+    X = rand(2, 10)
+    operators = OperatorEnum(; binary_operators=[+, *], unary_operators=[sin])
+
+    # Test different tree structures
+    @testset "Tree type: \$description" for (description, tree) in [
+        ("Single feature", Node(Float64; feature=1)),
+        ("Constant", Node(Float64; val=1.5)),
+        ("Binary op", Node(; op=1, l=Node(Float64; feature=1), r=Node(Float64; val=2.0))),
+        ("Unary op", Node(; op=1, l=Node(Float64; feature=1))),
+    ]
+        # Regular evaluation
+        result1, ok1 = eval_tree_array(tree, X, operators)
+
+        # Evaluation with buffer
+        buffer = zeros(5, size(X, 2))
+        buffer_ref = Ref(0)
+        eval_options = EvalOptions(; buffer=buffer, buffer_ref=buffer_ref)
+        result2, ok2 = eval_tree_array(tree, X, operators; eval_options)
+
+        # Results should be identical
+        @test result1 ≈ result2
+        @test ok1 == ok2
+    end
+end
+
+@testitem "Buffer index management" begin
+    using DynamicExpressions
+    using Test
+
+    X = rand(2, 10)
+    operators = OperatorEnum(; binary_operators=[+, *], unary_operators=[sin])
+
+    # Create a complex tree that will use multiple buffer slots
+    tree = Node(;
+        op=1,  # +
+        l=Node(; op=1, l=Node(Float64; feature=1)),  # sin(x1)
+        r=Node(; op=1, l=Node(Float64; feature=2), r=Node(Float64; val=2.0)),  # x2 + 2
+    )
+
+    # This tree needs more buffer space due to intermediate computations
+    buffer = zeros(10, size(X, 2))
+    buffer_ref = Ref(0)
+    eval_options = EvalOptions(; buffer=buffer, buffer_ref=buffer_ref)
+
+    # Index should start at 1
+    @test buffer_ref[] == 0
+
+    # Evaluate
+    result, ok = eval_tree_array(tree, X, operators; eval_options)
+
+    # Index should have advanced
+    @test buffer_ref[] == 2
+
+    # Reset and evaluate again
+    result2, ok2 = eval_tree_array(tree, X, operators; eval_options)
+    # (We expect the index to automatically reset)
+
+    # Results should be identical
+    @test result ≈ result2
+    @test ok == ok2
+    @test buffer_ref[] == 2
+end
+
+@testitem "Buffer error handling" begin
+    using DynamicExpressions
+    using Test
+
+    X = rand(2, 10)
+    operators = OperatorEnum(; binary_operators=[+, /, *], unary_operators=[sin])
+
+    # Create a tree that might produce NaN/Inf
+    tree = Node(;
+        op=2,  # /
+        l=Node(Float64; val=1.0),
+        r=Node(Float64; val=0.0),  # Division by zero
+    )
+
+    buffer = zeros(5, size(X, 2))
+    buffer_ref = Ref(0)
+    eval_options = EvalOptions(; buffer=buffer, buffer_ref=buffer_ref)
+
+    # Test with early_exit=true
+    result1, ok1 = eval_tree_array(tree, X, operators; eval_options)
+    @test !ok1
+end

--- a/test/test_buffered_evaluation.jl
+++ b/test/test_buffered_evaluation.jl
@@ -35,11 +35,11 @@ end
     operators = OperatorEnum(; binary_operators=[+, *], unary_operators=[sin])
 
     # Test different tree structures
-    @testset "Tree type: \$description" for (description, tree) in [
-        ("Single feature", Node(Float64; feature=1)),
-        ("Constant", Node(Float64; val=1.5)),
-        ("Binary op", Node(; op=1, l=Node(Float64; feature=1), r=Node(Float64; val=2.0))),
-        ("Unary op", Node(; op=1, l=Node(Float64; feature=1))),
+    for tree in [
+        Node(Float64; feature=1),
+        Node(Float64; val=1.5),
+        Node(; op=1, l=Node(Float64; feature=1), r=Node(Float64; val=2.0)),
+        Node(; op=1, l=Node(Float64; feature=1)),
     ]
         # Regular evaluation
         result1, ok1 = eval_tree_array(tree, X, operators)

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -47,6 +47,7 @@ end
 end
 
 include("test_evaluation.jl")
+include("test_buffered_evaluation.jl")
 
 @testitem "Test validity of integer expression evaluation" begin
     include("test_integer_evaluation.jl")


### PR DESCRIPTION
This PR adds the ability to evaluate expression trees with **zero allocations** by reusing a pre-allocated buffer.

```julia
    buffer = zeros(10, size(X, 2))
    eval_options = EvalOptions(; buffer=ArrayBuffer(buffer, Ref(0)))
    result, ok = eval_tree_array(tree, X, operators; eval_options)
```

The buffer size must be at least `(num_intermediate_results, num_samples)`, where `num_intermediate_results` depends on the tree structure. You can usually just set this equal to the maximum number of leafs.

Added tests as well.