### PR TITLE
update eval_tree_array with GenericOperatorEnum docstring from from AbstractMatrix to AbstractArray

### DIFF
--- a/src/Evaluate.jl
+++ b/src/Evaluate.jl
@@ -902,7 +902,7 @@ end
 end
 
 """
-    eval_tree_array(tree::AbstractExpressionNode, cX::AbstractMatrix, operators::GenericOperatorEnum; throw_errors::Bool=true)
+    eval_tree_array(tree::AbstractExpressionNode, cX::AbstractArray, operators::GenericOperatorEnum; throw_errors::Bool=true)
 
 Evaluate a generic binary tree (equation) over a given input data,
 whatever that input data may be. The `operators` enum contains all


### PR DESCRIPTION
Given that the rest of the docstring states "whatever that input data may be" cX should not be restricted to a matrix.