### PR TITLE
fix: Distinguish unloaded extensions from dispatch errors

### DIFF
--- a/ext/DynamicExpressionsBumperExt.jl
+++ b/ext/DynamicExpressionsBumperExt.jl
@@ -5,9 +5,12 @@ using DynamicExpressions:
     OperatorEnum, AbstractExpressionNode, tree_mapreduce, is_valid_array, EvalContext
 using DynamicExpressions.UtilsModule: ResultOk, counttuple
 
-import DynamicExpressions.ExtensionInterfaceModule: bumper_eval_tree_array, bumper_kern!
+import DynamicExpressions.ExtensionInterfaceModule:
+    _bumper_eval_tree_array, _is_extension_loaded, bumper_kern!
 
-function bumper_eval_tree_array(
+_is_extension_loaded(::Val{:Bumper}) = true
+
+function _bumper_eval_tree_array(
     tree::AbstractExpressionNode{T},
     cX::AbstractMatrix{T},
     operators::OperatorEnum,

--- a/ext/DynamicExpressionsSymbolicUtilsExt.jl
+++ b/ext/DynamicExpressionsSymbolicUtilsExt.jl
@@ -10,8 +10,15 @@ using DynamicExpressions.UtilsModule: deprecate_varmap
 using SymbolicUtils
 using SymbolicUtils: BasicSymbolic, SymReal, iscall, issym, isconst, unwrap_const
 
-import DynamicExpressions.ExtensionInterfaceModule: node_to_symbolic, symbolic_to_node
+import DynamicExpressions.ExtensionInterfaceModule:
+    _is_extension_loaded,
+    _node_to_symbolic,
+    _symbolic_to_node,
+    node_to_symbolic,
+    symbolic_to_node
 import DynamicExpressions.ValueInterfaceModule: is_valid
+
+_is_extension_loaded(::Val{:SymbolicUtils}) = true
 
 const SYMBOLIC_UTILS_TYPES = Union{<:Number,BasicSymbolic}
 const SUPPORTED_OPS = (cos, sin, exp, cot, tan, csc, sec, +, -, *, /)
@@ -286,7 +293,7 @@ will generate a symbolic equation in SymbolicUtils.jl format.
     operators, which then allows one to convert back to a `AbstractExpressionNode` format
     using `symbolic_to_node`.
 """
-function node_to_symbolic(
+function _node_to_symbolic(
     tree::AbstractExpressionNode{T,2},
     operators::AbstractOperatorEnum;
     variable_names::Union{AbstractVector{<:AbstractString},Nothing}=nothing,
@@ -309,7 +316,7 @@ function node_to_symbolic(
     )
     return substitute(expr, subs)
 end
-function node_to_symbolic(
+function _node_to_symbolic(
     tree::AbstractExpression,
     operators::Union{AbstractOperatorEnum,Nothing}=nothing;
     variable_names::Union{AbstractVector{<:AbstractString},Nothing}=nothing,
@@ -323,7 +330,7 @@ function node_to_symbolic(
     )
 end
 
-function symbolic_to_node(
+function _symbolic_to_node(
     eqn::BasicSymbolic,
     operators::AbstractOperatorEnum,
     ::Type{N}=Node;

--- a/ext/DynamicExpressionsZygoteExt.jl
+++ b/ext/DynamicExpressionsZygoteExt.jl
@@ -1,9 +1,12 @@
 module DynamicExpressionsZygoteExt
 
 using Zygote: gradient
-import DynamicExpressions.ExtensionInterfaceModule: _zygote_gradient, ZygoteGradient
+import DynamicExpressions.ExtensionInterfaceModule:
+    _is_extension_loaded, _zygote_gradient_impl, ZygoteGradient
 
-function _zygote_gradient(op::F, ::Val{degree}) where {F,degree}
+_is_extension_loaded(::Val{:Zygote}) = true
+
+function _zygote_gradient_impl(op::F, ::Val{degree}) where {F,degree}
     return ZygoteGradient{F,degree}(op)
 end
 

--- a/src/ExtensionInterface.jl
+++ b/src/ExtensionInterface.jl
@@ -1,11 +1,20 @@
 module ExtensionInterfaceModule
 
+_is_extension_loaded(::Val) = false
+
 function node_to_symbolic(args...; kws...)
-    return error("Please load the `SymbolicUtils` package to use `node_to_symbolic`.")
+    _is_extension_loaded(Val(:SymbolicUtils)) ||
+        error("Please load the `SymbolicUtils` package to use `node_to_symbolic`.")
+    return _node_to_symbolic(args...; kws...)
 end
+function _node_to_symbolic end
+
 function symbolic_to_node(args...; kws...)
-    return error("Please load the `SymbolicUtils` package to use `symbolic_to_node`.")
+    _is_extension_loaded(Val(:SymbolicUtils)) ||
+        error("Please load the `SymbolicUtils` package to use `symbolic_to_node`.")
+    return _symbolic_to_node(args...; kws...)
 end
+function _symbolic_to_node end
 
 struct ZygoteGradient{F,degree} <: Function
     op::F
@@ -19,12 +28,17 @@ end
 Base.show(io::IO, ::MIME"text/plain", g::ZygoteGradient) = show(io, g)
 
 function _zygote_gradient(args...)
-    return error("Please load the Zygote.jl package.")
+    _is_extension_loaded(Val(:Zygote)) || error("Please load the Zygote.jl package.")
+    return _zygote_gradient_impl(args...)
 end
+function _zygote_gradient_impl end
 
 function bumper_eval_tree_array(args...)
-    return error("Please load the Bumper.jl package to use this feature.")
+    _is_extension_loaded(Val(:Bumper)) ||
+        error("Please load the Bumper.jl package to use this feature.")
+    return _bumper_eval_tree_array(args...)
 end
+function _bumper_eval_tree_array end
 function bumper_kern! end
 
 _is_loopvectorization_loaded(_) = false  # COV_EXCL_LINE

--- a/test/test_initial_errors.jl
+++ b/test/test_initial_errors.jl
@@ -1,5 +1,7 @@
 using DynamicExpressions
 using DynamicExpressions: EvalContext
+using DynamicExpressions.ExtensionInterfaceModule:
+    _is_extension_loaded, _zygote_gradient, bumper_eval_tree_array
 using DispatchDoctor: allow_unstable
 using Test
 
@@ -46,3 +48,41 @@ tree = cos(2.1 * x1) + sin(x2)
         () -> tree(ones(2, 10), operators; eval_options=EvalContext(; turbo=Val(true)))
     )
 )
+
+# Loaded extensions should use normal dispatch for unsupported arguments instead of claiming
+# that the dependency is missing.
+using SymbolicUtils
+
+@test _is_extension_loaded(Val(:SymbolicUtils))
+@test !_is_extension_loaded(Val(:Zygote))
+@test !_is_extension_loaded(Val(:Bumper))
+@test_throws "Please load the Zygote.jl package." _zygote_gradient(nothing)
+@test_throws "Please load the Bumper.jl package" bumper_eval_tree_array(nothing)
+
+symbolic_x1 = node_to_symbolic(x1, operators)
+@test string(symbolic_x1) == "x1"
+@test string(symbolic_to_node(symbolic_x1, operators)) == "x1"
+@test_throws MethodError node_to_symbolic(nothing)
+@test_throws MethodError symbolic_to_node(nothing)
+
+using Zygote
+
+@test _is_extension_loaded(Val(:SymbolicUtils))
+@test _is_extension_loaded(Val(:Zygote))
+@test !_is_extension_loaded(Val(:Bumper))
+@test_throws "Please load the Bumper.jl package" bumper_eval_tree_array(nothing)
+
+@test only(_zygote_gradient(sin, Val(1))(1.0)) ≈ cos(1.0)
+@test_throws MethodError _zygote_gradient(nothing)
+
+using Bumper
+
+@test _is_extension_loaded(Val(:SymbolicUtils))
+@test _is_extension_loaded(Val(:Zygote))
+@test _is_extension_loaded(Val(:Bumper))
+
+bumper_result, bumper_ok =
+    tree(ones(2, 10), operators; eval_options=EvalContext(; bumper=Val(true)))
+@test bumper_ok
+@test bumper_result ≈ fill(cos(2.1) + sin(1.0), 10)
+@test_throws MethodError bumper_eval_tree_array(nothing)


### PR DESCRIPTION
DynamicExpressions currently implements several optional-package entry points as catch-all methods that always report that the corresponding extension is not loaded. Once SymbolicUtils, Zygote, or Bumper is loaded, an unsupported argument combination can still fall through to that catch-all and produce the same message, incorrectly blaming extension loading instead of method dispatch. The issue proposes an extension-presence predicate plus separate internal generics so the package can distinguish these cases without adding runtime overhead, and the maintainer acknowledged the problem. The supplied timeline contains no prior closed attempts or competing open pull requests.

## Summary

Add a shared, `Val`-dispatched extension-presence predicate in `src/ExtensionInterface.jl`, and make each affected public/core entry point check its extension state before delegating to a separate internal generic. Update the SymbolicUtils, Zygote, and Bumper extension modules to mark themselves loaded and attach their existing implementations to those internal generics, preserving current successful behavior and unloaded-package guidance. When an extension is loaded but no implementation matches, allow normal Julia dispatch to surface a `MethodError` rather than emitting the false “please load” message.

## Verification

- Before loading optional dependencies, `node_to_symbolic`, `symbolic_to_node`, Zygote-backed differentiation, and Bumper-backed evaluation retain their current package-specific guidance.
- After loading SymbolicUtils, Zygote, and Bumper, each supported entry point still reaches its extension implementation and returns the same result as before.
- After an extension is loaded, passing an unsupported argument shape to each affected entry point raises a dispatch error and does not claim that the dependency is missing.
- Loading one optional dependency marks only its own extension as available; absent extensions continue to use their existing helpful error paths.

Fixes #68
