### PR TITLE
feat(values): support optional invalid value construction

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -228,7 +228,22 @@ tested using Interfaces.jl. You can see the interfaces with:
 ```@docs
 DynamicExpressions.ExpressionInterface
 DynamicExpressions.NodeInterface
+DynamicExpressions.ValueInterface
+DynamicExpressions.invalid_value
 ```
+
+Custom value types can define `DynamicExpressions.invalid_value(::Type{T})` to
+construct a `T` rejected by `DynamicExpressions.is_valid`. This optional method
+fills failed convenience evaluations, including buffers that have not yet been
+initialized. It receives no value or runtime shape. Types without an invalid
+member can use `eval_tree_array` and inspect its completion flag instead.
+
+Fused evaluation propagates an existing invalid intermediate unchanged. The
+output of `eval_tree_array` is unspecified when its completion flag is false.
+With `early_exit=false`, unary fused kernels still skip an outer operator when
+its intermediate is invalid; unfused evaluation calls that operator. This
+existing difference remains, so use `use_fused=false` when an outer operator
+must recover invalid intermediates.
 
 You can declare a new type as implementing these with, e.g.,
 

--- a/docs/src/eval.md
+++ b/docs/src/eval.md
@@ -31,8 +31,9 @@ and triplets of operations for lower memory usage.
 
 # Returns
 - `output::AbstractVector{T}`: the result, which is a 1D array.
-    Any NaN, Inf, or other failure during the evaluation will result in the entire
-    output array being set to NaN.
+    A failed evaluation fills the output with `DynamicExpressions.invalid_value(T)`.
+    Floating-point types return NaN. Custom types need this optional method to
+    represent failed outputs; otherwise use `eval_tree_array` and its completion flag.
 ```
 
 For example,

--- a/ext/DynamicExpressionsLoopVectorizationExt.jl
+++ b/ext/DynamicExpressionsLoopVectorizationExt.jl
@@ -152,7 +152,13 @@ function deg2_branch0_eval(
             x2 = ifelse(constant2, value2, cX[feature2, j])
             x3 = ifelse(constant3, value3, cX[feature3, j])
             branch_x = branch_op(x1, x2)
-            cumulator[j] = isfinite(branch_x) & isfinite(x3) ? op(branch_x, x3) : T(Inf)
+            cumulator[j] = if !isfinite(branch_x)
+                branch_x
+            elseif !isfinite(x3)
+                x3
+            else
+                op(branch_x, x3)
+            end
         end  # COV_EXCL_LINE
     elseif side === :right && eval_context.early_exit isa Val{true}
         @inbounds @simd for j in axes(cX, 2)
@@ -160,7 +166,13 @@ function deg2_branch0_eval(
             x2 = ifelse(constant2, value2, cX[feature2, j])
             x3 = ifelse(constant3, value3, cX[feature3, j])
             branch_x = branch_op(x2, x3)
-            cumulator[j] = isfinite(x1) & isfinite(branch_x) ? op(x1, branch_x) : T(Inf)
+            cumulator[j] = if !isfinite(x1)
+                x1
+            elseif !isfinite(branch_x)
+                branch_x
+            else
+                op(x1, branch_x)
+            end
         end  # COV_EXCL_LINE
     elseif side === :left
         @turbo for j in axes(cX, 2)

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -13,6 +13,7 @@ using ..OperatorEnumModule: OperatorEnum
 using ..NodeModule: AbstractExpressionNode, with_type_parameters, tree_mapreduce
 using ..EvaluateModule: eval_tree_array
 using ..EvaluateDerivativeModule: eval_grad_tree_array
+using ..UtilsModule: set_invalid!
 
 struct NodeTangent{T,N<:AbstractExpressionNode{T},A<:AbstractArray{T}} <: AbstractTangent
     tree::N
@@ -39,7 +40,7 @@ function CRC.rrule(
     primal, complete = eval_tree_array(tree, X, operators; kws...)
 
     if !complete
-        primal .= NaN
+        set_invalid!(primal)
     end
 
     return (primal, complete), EvalPullback(tree, X, operators)
@@ -60,7 +61,7 @@ function (e::EvalPullback)((thunked_dY, _))
     )
 
     if !complete
-        dX_constants_dY .= NaN
+        set_invalid!(dX_constants_dY)
     end
 
     nfeatures = size(e.X, 1)

--- a/src/DynamicExpressions.jl
+++ b/src/DynamicExpressions.jl
@@ -3,8 +3,8 @@ module DynamicExpressions
 using DispatchDoctor: @stable, @unstable
 
 @stable default_mode = "disable" begin
-    include("Utils.jl")
     include("ValueInterface.jl")
+    include("Utils.jl")
     include("ExtensionInterface.jl")
     include("OperatorEnum.jl")
     include("Node.jl")
@@ -31,6 +31,7 @@ macro ignore(args...) end
 import .UtilsModule: Nullable
 import .ValueInterfaceModule:
     is_valid,
+    invalid_value,
     is_valid_array,
     get_number_type,
     pack_scalar_constants!,

--- a/src/Evaluate.jl
+++ b/src/Evaluate.jl
@@ -140,10 +140,11 @@ This holds evaluation policy and call-scoped mutable state.
 - `early_exit::Val{E}=Val(true)`: If `Val{true}`, any element of any step becoming
     `NaN` or `Inf` will terminate the computation. For `eval_tree_array`, this will
     result in the second return value, the completion flag, being `false`. For 
-    calling an expression using `tree(X)`, this will result in `NaN`s filling
-    the entire buffer. This early exit is performed to avoid wasting compute cycles.
-    Setting `Val{false}` will continue the computation as usual and thus result in
-    `NaN`s only in the elements that actually have `NaN`s.
+    calling an expression using `tree(X)`, this fills the entire buffer with
+    `invalid_value(T)`, which defaults to NaN for floating-point types.
+    Setting `Val{false}` disables early termination. Unary fused kernels still
+    propagate invalid intermediates without calling the outer operator; use
+    `use_fused=false` if that operator should recover invalid values.
 - `buffer::Union{ArrayBuffer,Nothing}`: If not `nothing`, use this buffer for evaluation.
     This should be an instance of `ArrayBuffer` which has an `array` field and an
     `index` field used to iterate which buffer slot to use. The buffer creator must
@@ -719,7 +720,7 @@ function deg1_l2_ll0_lr0_eval(
         @inbounds @simd for j in axes(cX, 2)
             x_l =
                 op_l(val_ll, feature_at(cX, input_lr_index, feature_lr, j, index_style))::T
-            x = is_valid(x_l) ? op(x_l)::T : T(Inf)
+            x = is_valid(x_l) ? op(x_l)::T : x_l
             cumulator[j] = x
             input_lr_index += feature_stride
         end  # COV_EXCL_LINE
@@ -734,7 +735,7 @@ function deg1_l2_ll0_lr0_eval(
         @inbounds @simd for j in axes(cX, 2)
             x_l =
                 op_l(feature_at(cX, input_ll_index, feature_ll, j, index_style), val_lr)::T
-            x = is_valid(x_l) ? op(x_l)::T : T(Inf)
+            x = is_valid(x_l) ? op(x_l)::T : x_l
             cumulator[j] = x
             input_ll_index += feature_stride
         end  # COV_EXCL_LINE
@@ -751,7 +752,7 @@ function deg1_l2_ll0_lr0_eval(
                 feature_at(cX, input_ll_index, feature_ll, j, index_style),
                 feature_at(cX, input_lr_index, feature_lr, j, index_style),
             )::T
-            x = is_valid(x_l) ? op(x_l)::T : T(Inf)
+            x = is_valid(x_l) ? op(x_l)::T : x_l
             cumulator[j] = x
             input_ll_index += feature_stride
             input_lr_index += feature_stride
@@ -784,7 +785,7 @@ function deg1_l1_ll0_eval(
         cumulator = get_array(eval_context.buffer, cX, axes(cX, 2))
         @inbounds @simd for j in axes(cX, 2)
             x_l = op_l(feature_at(cX, input_ll_index, feature_ll, j, index_style))::T
-            x = is_valid(x_l) ? op(x_l)::T : T(Inf)
+            x = is_valid(x_l) ? op(x_l)::T : x_l
             cumulator[j] = x
             input_ll_index += feature_stride
         end  # COV_EXCL_LINE
@@ -797,7 +798,7 @@ end
 ) where {T<:Number,F,F2,early_exit}
     branch_x = branch_op(x1, x2)::T
     return if early_exit && (!is_valid(branch_x) || !is_valid(x3))
-        T(Inf)
+        is_valid(branch_x) ? x3 : branch_x
     else
         op(branch_x, x3)::T
     end
@@ -808,7 +809,7 @@ end
 ) where {T<:Number,F,F2,early_exit}
     branch_x = branch_op(x2, x3)::T
     return if early_exit && (!is_valid(x1) || !is_valid(branch_x))
-        T(Inf)
+        is_valid(x1) ? branch_x : x1
     else
         op(x1, branch_x)::T
     end

--- a/src/EvaluationHelpers.jl
+++ b/src/EvaluationHelpers.jl
@@ -5,7 +5,7 @@ import ..OperatorEnumModule: AbstractOperatorEnum, OperatorEnum, GenericOperator
 import ..NodeModule: AbstractExpressionNode
 import ..EvaluateModule: eval_tree_array
 import ..EvaluateDerivativeModule: eval_grad_tree_array
-import ..UtilsModule: set_nan!
+import ..UtilsModule: set_invalid!
 
 # Evaluation:
 """
@@ -23,12 +23,12 @@ and triplets of operations for lower memory usage.
 
 # Returns
 - `output::AbstractVector{T}`: the result, which is a 1D array.
-    Any NaN, Inf, or other failure during the evaluation will result in the entire
-    output array being set to NaN.
+    A failed evaluation fills the output with `invalid_value(T)`. Floating-point
+    types return NaN; custom types need the optional `invalid_value` method.
 """
 function (tree::AbstractExpressionNode)(X, operators::OperatorEnum; kws...)
     out, did_finish = eval_tree_array(tree, X, operators; kws...)
-    !did_finish && set_nan!(out)
+    !did_finish && set_invalid!(out)
     return out
 end
 """
@@ -57,7 +57,7 @@ function _grad_evaluator(
     tree::AbstractExpressionNode, X, operators::OperatorEnum; variable=Val(true), kws...
 )
     _, grad, did_complete = eval_grad_tree_array(tree, X, operators; variable, kws...)
-    !did_complete && set_nan!(grad)
+    !did_complete && set_invalid!(grad)
     return grad
 end
 function _grad_evaluator(

--- a/src/NonDifferentiableDeclarations.jl
+++ b/src/NonDifferentiableDeclarations.jl
@@ -3,7 +3,7 @@ module NonDifferentiableDeclarationsModule
 # COV_EXCL_START
 
 using ChainRulesCore: @non_differentiable
-import ..UtilsModule: set_nan!
+import ..UtilsModule: set_invalid!
 import ..OperatorEnumModule: AbstractOperatorEnum
 import ..NodeModule: AbstractExpressionNode, AbstractNode
 import ..NodeUtilsModule: tree_mapreduce
@@ -16,7 +16,7 @@ import ..ExpressionModule:
 @non_differentiable get_operators(ex::Union{AbstractExpression,AbstractExpressionNode}, operators::Union{AbstractOperatorEnum,Nothing})
 @non_differentiable get_variable_names(ex::AbstractExpression, variable_names::Union{AbstractVector{<:AbstractString},Nothing})
 @non_differentiable _validate_input(ex::AbstractExpression, X, operators::Union{AbstractOperatorEnum,Nothing})
-@non_differentiable set_nan!(::Any)
+@non_differentiable set_invalid!(::Any)
 #! format: on
 
 # COV_EXCL_STOP

--- a/src/ParametricExpression.jl
+++ b/src/ParametricExpression.jl
@@ -8,7 +8,7 @@ using ..NodeModule: AbstractExpressionNode, Node, tree_mapreduce
 using ..ExpressionModule:
     AbstractExpression, Metadata, with_contents, with_metadata, unpack_metadata
 using ..ChainRulesModule: NodeTangent
-using ..UtilsModule: Nullable, set_nan!
+using ..UtilsModule: Nullable, set_invalid!
 
 import ..NodeModule:
     constructorof,
@@ -365,7 +365,7 @@ function (ex::ParametricExpression)(
     kws...,
 ) where {T}
     (output, flag) = eval_tree_array(ex, X, classes, operators; kws...)
-    !flag && set_nan!(output)
+    !flag && set_invalid!(output)
     return output
 end
 function eval_tree_array(

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -3,6 +3,7 @@ module UtilsModule
 
 using MacroTools: postwalk, @capture, splitdef, combinedef
 using DispatchDoctor: @unstable
+import ..ValueInterfaceModule: invalid_value
 
 # Returns two arrays
 macro return_on_false2(flag, retval, retval2)
@@ -70,8 +71,8 @@ end
     return Nullable(x.null, convert(T, x.x))
 end
 
-function set_nan!(out)
-    out .= convert(eltype(out), NaN)
+function set_invalid!(out)
+    fill!(out, invalid_value(eltype(out)))
     return nothing
 end
 

--- a/src/ValueInterface.jl
+++ b/src/ValueInterface.jl
@@ -5,6 +5,23 @@ using Interfaces: Interfaces, @interface, @implements, Arguments
 is_valid(x::T) where {T} = true  # COV_EXCL_LINE
 is_valid(x::T) where {T<:Number} = isfinite(x) && !isnan(x)
 
+"""
+    invalid_value(::Type{T})
+
+Construct a value of type `T` for which `is_valid` returns `false`.
+This optional part of [`ValueInterface`](@ref) is used by convenience evaluation
+to fill failed outputs. Floating-point and complex floating-point types return NaN.
+Custom types representing invalid states may implement this method. Types with
+no invalid member, such as integers, need not implement it; use `eval_tree_array`
+and its completion flag when failed outputs cannot be represented.
+
+The constructor receives only the type, so it cannot preserve runtime-dependent
+shapes. Every value returned must have type `T` and be invalid.
+"""
+function invalid_value end
+invalid_value(::Type{T}) where {T<:AbstractFloat} = T(NaN)
+invalid_value(::Type{Complex{T}}) where {T<:AbstractFloat} = Complex{T}(T(NaN), zero(T))
+
 is_valid_array(x::AbstractArray{T}) where {T} = all(is_valid, x)
 is_valid_array(x::AbstractArray{T}) where {T<:Number} = is_valid(sum(x))
 
@@ -64,6 +81,10 @@ Note that this will return 1 for scalars.
 # Interface.jl integration #####################################################
 ################################################################################
 
+function _check_invalid_value(x::T) where {T}
+    value = invalid_value(T)
+    return value isa T && !is_valid(value)
+end
 function _check_is_valid(x)
     return is_valid(x) isa Bool
 end
@@ -137,7 +158,9 @@ vi_components = (
         unpack_scalar_constants = "unpacks scalar constants from an array" => _check_unpack_scalar_constants,
         count_scalar_constants = "counts how many scalar constants the value has" => _check_count_scalar_constants,
     ),
-    optional = (;)
+    optional = (
+        invalid_value = "constructs an invalid value of the same type" => _check_invalid_value,
+    )
 )
 vi_description = (
     "Defines the interface for types operated on by `DynamicExpressions`. " *
@@ -148,5 +171,7 @@ vi_description = (
 
 @interface(ValueInterface, Any, vi_components, vi_description)
 @implements(ValueInterface, Number, [Arguments()])
+@implements(ValueInterface{(:invalid_value,)}, AbstractFloat, [Arguments()])
+@implements(ValueInterface{(:invalid_value,)}, Complex{<:AbstractFloat}, [Arguments()])
 
 end

--- a/test/test_invalid_values.jl
+++ b/test/test_invalid_values.jl
@@ -1,0 +1,86 @@
+using DynamicExpressions: DynamicExpressions as DE
+using Interfaces: Interfaces
+
+struct TextValue
+    text::String
+end
+DE.is_valid(x::TextValue) = !isempty(x.text)
+DE.invalid_value(::Type{TextValue}) = TextValue("")
+inner(x::TextValue) = TextValue(x.text == "bad" ? "" : "ok")
+function inner2(x::TextValue, y::TextValue)
+    return TextValue(x.text == "bad" || y.text == "bad" ? "" : "ok")
+end
+outer(x::TextValue) = TextValue("outer")
+
+@testset "Invalid intermediates without scalar constructors" begin
+    ops = DE.OperatorEnum(;
+        unary_operators=(outer, inner),
+        binary_operators=(inner2,),
+        define_helper_functions=false,
+    )
+    leaf = DE.Node{TextValue}(; feature=1)
+    c = DE.Node{TextValue}(; val=TextValue("ok"))
+    branches = [
+        DE.Node{TextValue}(; op=2, l=leaf),
+        DE.Node{TextValue}(; op=1, l=c, r=leaf),
+        DE.Node{TextValue}(; op=1, l=leaf, r=c),
+        DE.Node{TextValue}(; op=1, l=leaf, r=leaf),
+    ]
+    bad = reshape([TextValue("ok"), TextValue("bad")], 1, :)
+    good = reshape([TextValue("ok"), TextValue("ok")], 1, :)
+    for fused in (false, true), branch in branches
+        ctx = DE.EvalContext(; use_fused=fused)
+        tree = DE.Node{TextValue}(; op=1, l=branch)
+        _, complete = DE.eval_tree_array(tree, bad, ops; eval_context=ctx)
+        @test !complete
+        result, complete = DE.eval_tree_array(tree, good, ops; eval_context=ctx)
+        @test complete
+        @test all(x -> x.text == "outer", result)
+        parent = DE.Node{TextValue}(; op=1, l=tree)
+        _, complete = DE.eval_tree_array(parent, bad, ops; eval_context=ctx)
+        @test !complete
+        @test all(x -> !DE.is_valid(x), tree(bad, ops; eval_context=ctx))
+    end
+    invalid_constant = DE.Node{TextValue}(; val=TextValue(""))
+    for buffer in (nothing, DE.ArrayBuffer(Vector{TextValue}[], Ref(0)))
+        ctx = DE.EvalContext(; buffer)
+        @test all(x -> !DE.is_valid(x), invalid_constant(good, ops; eval_context=ctx))
+    end
+end
+
+struct Force
+    x::Float64
+    y::Float64
+    z::Float64
+end
+DE.is_valid(f::Force) = all(isfinite, (f.x, f.y, f.z))
+DE.invalid_value(::Type{Force}) = Force(NaN, NaN, NaN)
+
+@testset "Optional invalid values" begin
+    for T in (Float16, Float32, Float64, ComplexF32, ComplexF64, Force, TextValue)
+        value = @inferred DE.invalid_value(T)
+        @test value isa T
+        @test !DE.is_valid(value)
+    end
+    @test Interfaces.test(DE.ValueInterface{(:invalid_value,)}, Float64, [1.0])
+    @test Interfaces.test(DE.ValueInterface{(:invalid_value,)}, ComplexF64, [1.0 + 2.0im])
+    @test !applicable(DE.invalid_value, Int)
+    @test !applicable(DE.invalid_value, Bool)
+    int_ops = DE.OperatorEnum(; binary_operators=(+,), define_helper_functions=false)
+    t = DE.Node{Int}(; op=1, l=DE.Node{Int}(; feature=1), r=DE.Node{Int}(; val=2))
+    @test DE.eval_tree_array(t, reshape([1, 2], 1, :), int_ops) == ([3, 4], true)
+    force_ops = DE.OperatorEnum(;
+        unary_operators=(identity,), define_helper_functions=false
+    )
+    t_force = DE.Node{Force}(; val=DE.invalid_value(Force))
+    output = t_force(reshape([Force(1, 2, 3)], 1, :), force_ops)
+    @test all(x -> x isa Force && !DE.is_valid(x), output)
+end
+
+@testset "Numeric fused invalid propagation" begin
+    kernel = DE.EvaluateModule._fused_binary3
+    @test isnan(kernel(+, +, NaN, 1.0, 2.0, Val(:left), Val(true)))
+    @test isnan(kernel(+, +, 1.0, 2.0, NaN, Val(:left), Val(true)))
+    @test isnan(kernel(+, +, NaN, 1.0, 2.0, Val(:right), Val(true)))
+    @test isnan(kernel(+, +, 1.0, 2.0, NaN, Val(:right), Val(true)))
+end

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -57,6 +57,10 @@ end
     include("test_nan_detection.jl")
 end
 
+@testitem "Test custom invalid values" begin
+    include("test_invalid_values.jl")
+end
+
 @testitem "Test OperatorEnum with non-number type" begin
     include("test_non_number_eval_tree_array.jl")
 end


### PR DESCRIPTION
## Why
Custom value types can represent invalid states without accepting a scalar constructor such as `Force(Inf)`.

## Scope
- Add optional `invalid_value(::Type{T})` to `ValueInterface`, paired with `is_valid`. Floating-point and complex floating-point types return NaN. Integers and Boolean values require no method.
- Propagate existing invalid intermediates in fused kernels, including the numeric LoopVectorization path.
- Replace internal `set_nan!` with `set_invalid!` for convenience evaluation, parametric evaluation, gradients, and ChainRules outputs. Fill uninitialized buffers without reading their elements.
- Document the type-only hook and its runtime-shape limitation.

## Tradeoffs
Unary fused kernels still skip the outer operator for invalid intermediates with `early_exit=false`. Unfused evaluation calls that operator. This pre-existing difference remains documented. Propagation preserves the invalid intermediate instead of replacing it with positive infinity.

## Blast Radius
Valid evaluation and completion flags retain their contracts. Types without invalid members can use `eval_tree_array` and its completion flag. No package release is part of this PR.

## Verification
- Reproduced the pre-change custom-value fused failure with a string-backed type and no scalar constructor.
- Targeted Julia test items passed 393 assertions, covering derivatives, ChainRules, integer evaluation, NaN detection, custom values, parametric expressions, and fused paths.
- Additional convenience-output smoke checks passed 6 assertions for custom reference values, parametric outputs, gradient outputs, and ChainRules.
- Local PySR integration resolved SymbolicRegression 2.4.0 with this checkout through `Pkg.develop`. TypeSpec invalid-hook tests passed. The Force example completed a small fit and returned finite three-component predictions without a scalar constructor.
- JuliaFormatter 1.0.62 passed for changed Julia files.
